### PR TITLE
chore: GitHub リポジトリ基本設定の整備

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,1 @@
+* @yabutayukinari

--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,63 @@
+name: Bug report
+description: バグ報告
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        バグの内容を以下のテンプレートに沿って記入してください。
+
+  - type: textarea
+    id: summary
+    attributes:
+      label: 概要
+      description: 何が起きていますか？
+      placeholder: 例) 管理画面でユーザー編集を保存すると 500 エラーが返る
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: 再現手順
+      description: 再現するための具体的な手順
+      placeholder: |
+        1. /admin/users にアクセス
+        2. 任意のユーザーの「編集」をクリック
+        3. ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: expected
+    attributes:
+      label: 期待する挙動
+    validations:
+      required: true
+
+  - type: textarea
+    id: actual
+    attributes:
+      label: 実際の挙動
+      description: エラーメッセージ・スタックトレース・スクリーンショットなど
+    validations:
+      required: true
+
+  - type: input
+    id: php-version
+    attributes:
+      label: PHP バージョン
+      placeholder: "8.3.x"
+
+  - type: input
+    id: laravel-version
+    attributes:
+      label: Laravel バージョン
+      placeholder: "13.x"
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 補足情報
+      description: その他の関連情報

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,0 +1,1 @@
+blank_issues_enabled: true

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,31 @@
+name: Feature request
+description: 機能要望
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: textarea
+    id: problem
+    attributes:
+      label: 解決したい課題
+      description: どんな課題・困りごとを解決したいか
+    validations:
+      required: true
+
+  - type: textarea
+    id: proposal
+    attributes:
+      label: 提案する機能
+      description: どのような機能で課題を解決するか
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: 代替案
+      description: 検討した別の方法があれば記入
+
+  - type: textarea
+    id: additional
+    attributes:
+      label: 補足情報

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,46 @@
+version: 2
+updates:
+  - package-ecosystem: composer
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - php
+    groups:
+      php-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: npm
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    open-pull-requests-limit: 10
+    labels:
+      - dependencies
+      - javascript
+    groups:
+      js-minor-and-patch:
+        update-types:
+          - minor
+          - patch
+
+  - package-ecosystem: github-actions
+    directory: "/"
+    schedule:
+      interval: weekly
+      day: monday
+      time: "09:00"
+      timezone: Asia/Tokyo
+    labels:
+      - dependencies
+      - github-actions

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,78 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  php:
+    name: PHP ${{ matrix.php }} (analysis & tests)
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ["8.3"]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup PHP
+        uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          extensions: mbstring, intl, pdo_sqlite, sqlite3, bcmath
+          coverage: none
+          tools: composer:v2
+
+      - name: Get composer cache directory
+        id: composer-cache
+        run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
+
+      - name: Cache composer dependencies
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.composer-cache.outputs.dir }}
+          key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
+          restore-keys: |
+            ${{ runner.os }}-php-${{ matrix.php }}-composer-
+
+      - name: Install composer dependencies
+        run: composer install --prefer-dist --no-interaction --no-progress
+
+      - name: Prepare application
+        run: |
+          cp .env.example .env
+          php artisan key:generate
+
+      - name: Run static analysis (csf, cs, sa, md)
+        run: composer build
+
+      - name: Run PHPUnit
+        run: composer test
+
+  frontend:
+    name: Frontend build
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+          cache: npm
+
+      - name: Install npm dependencies
+        run: npm ci
+
+      - name: Build assets
+        run: npm run build


### PR DESCRIPTION
## Summary
- Dependabot を追加 (composer / npm / github-actions、毎週月曜 09:00 JST)
- CI ワークフローを追加 (`composer build` + `composer test` を PHP 8.3、フロントエンドビルドを Node 22 で)
- `.github/CODEOWNERS` を追加 (`* @yabutayukinari`)
- Issue テンプレートを追加 (Bug report / Feature request)
- リポジトリ設定 `delete_branch_on_merge=true` を有効化 (API 経由で適用済み)

## Notes
- `main` ブランチ保護は今回見送り (Private + GitHub Free では Branch Protection / Rulesets が利用不可。Pro へのアップグレードまたは Public 化が必要)
- CI の PHPUnit は `phpunit.xml` の SQLite in-memory で動作するため、追加の DB セットアップは不要

## Test plan
- [ ] このブランチで CI ワークフローが PR チェックとして起動することを確認
- [ ] `composer build` (csf/cs/sa/md) が CI 上で通ること
- [ ] `composer test` が CI 上で通ること
- [ ] `npm run build` が CI 上で通ること
- [ ] Dependabot が初回スキャンを実行し、必要に応じて PR を作成すること
- [ ] Issue 作成時に新しいテンプレートが表示されること

🤖 Generated with [Claude Code](https://claude.com/claude-code)