### PR TITLE
ci: add CodeQL workflow for JS/TS analysis

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,44 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # Weekly scan to catch new queries against unchanged code (Mon 09:00 JST)
+    - cron: "0 0 * * 1"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        # CodeQL does not support PHP. JavaScript/TypeScript covers the frontend assets only.
+        language: [javascript-typescript]
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: ${{ matrix.language }}
+          queries: security-and-quality
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: "/language:${{ matrix.language }}"


### PR DESCRIPTION
## Summary
- Add GitHub-managed CodeQL static analysis workflow (`.github/workflows/codeql.yml`)
- Runs on push to `main`, all PRs to `main`, and weekly cron (Mon 00:00 UTC) to catch new queries
- Uses `security-and-quality` query suite (broader than default)

## Caveat
CodeQL does **not** support PHP, so this only analyzes the frontend JavaScript/TypeScript surface (`resources/js/app.js`, `vite.config.js`). PHP-side static analysis remains covered by Larastan/PHPStan + PHPCS + PHP CS Fixer + PHPMD via the existing `composer build` pipeline.

## Test plan
- [ ] CI runs the new `CodeQL` workflow on this PR
- [ ] No alerts surface on the current minimal JS code (or if any do, evaluate them)
- [ ] Workflow finishes within a reasonable time (~2-3 min for this repo size)

🤖 Generated with [Claude Code](https://claude.com/claude-code)