### PR TITLE
ci: add composer audit and npm audit to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,6 +62,9 @@ jobs:
       - name: Install composer dependencies
         run: composer install --prefer-dist --no-interaction --no-progress
 
+      - name: Audit composer dependencies for known vulnerabilities
+        run: composer audit --locked
+
       - name: Prepare environment (.env)
         run: cp .env.ci .env
 
@@ -114,6 +117,10 @@ jobs:
 
       - name: Install npm dependencies
         run: npm ci
+
+      - name: Audit npm dependencies for known vulnerabilities
+        # high+ only — moderate/low transitive npm advisories are too noisy to gate PRs on
+        run: npm audit --audit-level=high
 
       - name: Build assets
         run: npm run build


### PR DESCRIPTION
## Summary
- Add `composer audit --locked` to the `php` CI job (runs after `composer install`)
- Add `npm audit --audit-level=high` to the `frontend` CI job (runs after `npm ci`)
- Both gates fail the build when known vulnerabilities are detected in the locked dependency graph

## Threshold rationale
- **composer audit**: default threshold (any advisory blocks). PHP advisories tend to be high-signal, and the dependency tree here is small.
- **npm audit**: `--audit-level=high` only. Moderate/low npm advisories are typically transitive and too noisy to gate PRs on; high/critical still hard-fail.

## Verified locally
Both audits are clean against the current `composer.lock` and `package-lock.json`:
- `composer audit --locked` → No security vulnerability advisories found.
- `npm audit --audit-level=high` → found 0 vulnerabilities

## Test plan
- [ ] CI passes on this PR (no advisories yet)
- [ ] Future advisory against a locked dep correctly fails CI (will surface naturally)

🤖 Generated with [Claude Code](https://claude.com/claude-code)