### PR TITLE
ci: upload PHPUnit coverage to Codecov

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -91,6 +91,13 @@ jobs:
             --coverage-html build/coverage/html \
             --coverage-clover build/coverage/clover.xml
 
+      - name: Upload coverage to Codecov
+        uses: codecov/codecov-action@v5
+        with:
+          files: build/coverage/clover.xml
+          flags: php
+          token: ${{ secrets.CODECOV_TOKEN }}
+
       - name: Upload coverage artifact
         uses: actions/upload-artifact@v4
         with:


### PR DESCRIPTION
## Summary
- Add `codecov/codecov-action@v5` step after the PHPUnit run to upload `build/coverage/clover.xml`
- Tagged with the `php` flag for future matrix/multi-language flexibility
- Existing artifact upload (`coverage-php-*`) is preserved as a local fallback

## Required setup before merging
The action references `secrets.CODECOV_TOKEN`. To make uploads reliable:
1. Sign in at [codecov.io](https://codecov.io) with GitHub and add this repo
2. Copy the upload token from Codecov repo settings
3. Add it as repo secret `CODECOV_TOKEN` (Settings → Secrets and variables → Actions → New secret)

Public-repo tokenless uploads still work without the secret, but are subject to rate limiting and can be unreliable.

## Why no codecov.yml yet
Default Codecov targets (auto) are fine while we calibrate against the current coverage profile. We can add a `codecov.yml` later to tune project/patch thresholds.

## Test plan
- [ ] Configure `CODECOV_TOKEN` repo secret
- [ ] Confirm the new step succeeds on this PR
- [ ] Confirm coverage report appears at `codecov.io/gh/yabutayukinari/type89`
- [ ] Confirm Codecov leaves a coverage diff comment on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)