### PR TITLE
ci: auto-merge Dependabot minor/patch PRs

### DIFF
--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -1,0 +1,29 @@
+name: Dependabot auto-merge
+
+on: pull_request
+
+permissions:
+  contents: write
+  pull-requests: write
+
+jobs:
+  auto-merge:
+    if: github.event.pull_request.user.login == 'dependabot[bot]'
+    runs-on: ubuntu-latest
+    steps:
+      - name: Fetch Dependabot metadata
+        id: metadata
+        uses: dependabot/fetch-metadata@v2
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Approve and enable auto-merge for minor/patch updates
+        if: |
+          steps.metadata.outputs.update-type == 'version-update:semver-minor' ||
+          steps.metadata.outputs.update-type == 'version-update:semver-patch'
+        env:
+          PR_URL: ${{ github.event.pull_request.html_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          gh pr review --approve "$PR_URL"
+          gh pr merge --auto --squash "$PR_URL"


### PR DESCRIPTION
## Summary
- Add `.github/workflows/dependabot-auto-merge.yml`
- Auto-approves Dependabot PRs for **minor and patch** semver updates and enables GitHub's auto-merge (squash)
- **Major** updates are intentionally left for manual review (e.g. last week's PHP CodeSniffer 3 → 4 was correctly handled by hand)

## How it works
1. PR opened by `dependabot[bot]` triggers the workflow
2. `dependabot/fetch-metadata@v2` extracts the update type (major / minor / patch)
3. If minor or patch:
   - `gh pr review --approve` adds an approving review (using `GITHUB_TOKEN`)
   - `gh pr merge --auto --squash` enables auto-merge — GitHub then waits for required status checks to pass before merging

## Required GitHub settings before this is effective
1. **Settings → General → Pull Requests → Allow auto-merge** ← must be enabled
2. **Settings → Branches → Branch protection for `main`**
   - Require status checks to pass before merging
   - Mark CI jobs as required (recommended: `PHP 8.4 (analysis & tests)`, `Frontend build`, and `Analyze (javascript-typescript)` once #51 merges)
   - Without required checks, auto-merge cannot gate on CI

## Safety considerations
- Limited to minor/patch only — semver-breaking majors still require human review
- CI gates the merge: `composer audit`, `npm audit`, PHPUnit, static analysis, CodeQL all run first
- Approval comes from `GITHUB_TOKEN` (the bot), not a human — fine since Dependabot can't be its own reviewer

## Test plan
- [ ] Enable auto-merge in repo settings
- [ ] Configure branch protection with required status checks
- [ ] Wait for next Dependabot PR (next Monday 09:00 JST) and confirm it auto-merges after CI passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)