### PR TITLE
docs: add status badges to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,11 @@
 # type_89
 
+[![CI](https://github.com/yabutayukinari/type89/actions/workflows/ci.yml/badge.svg?branch=main)](https://github.com/yabutayukinari/type89/actions/workflows/ci.yml)
+[![CodeQL](https://github.com/yabutayukinari/type89/actions/workflows/codeql.yml/badge.svg?branch=main)](https://github.com/yabutayukinari/type89/actions/workflows/codeql.yml)
+[![codecov](https://codecov.io/gh/yabutayukinari/type89/branch/main/graph/badge.svg)](https://codecov.io/gh/yabutayukinari/type89)
+[![PHP](https://img.shields.io/badge/php-%5E8.4-777bb4)](https://www.php.net/)
+[![Laravel](https://img.shields.io/badge/laravel-13-ff2d20)](https://laravel.com/)
+
 Laravel をベースにしたユーザー管理アプリケーションのプラクティス用リポジトリです。
 
 ## 技術スタック


### PR DESCRIPTION
## Summary
Add five status badges to the top of `README.md`:

- **CI** — GitHub Actions workflow status (PHP analysis & tests + frontend build)
- **CodeQL** — security analysis status
- **Codecov** — current coverage on `main`
- **PHP `^8.4`** — required PHP version
- **Laravel 13** — framework version

Gives a quick health check at a glance from the repo home page.

## Notes
- The Codecov badge will start populating once Codecov has processed the first uploads from `main` (the integration was added in #53).
- No coverage threshold is enforced yet — the badge is informational only.

## Test plan
- [ ] Badges render correctly on the rendered README
- [ ] Badge links navigate to the corresponding workflow / dashboard

🤖 Generated with [Claude Code](https://claude.com/claude-code)