### PR TITLE
chore: add Lefthook for pre-commit and pre-push checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,18 @@ php artisan key:generate
 php artisan migrate
 ```
 
+### Git フック (Lefthook)
+
+`lefthook.yml` で pre-commit / pre-push フックを管理しています。初回のみ以下を実行してください。
+
+```bash
+brew install lefthook    # 未導入の場合
+lefthook install         # .git/hooks にフックを登録
+```
+
+- **pre-commit**: ステージ済み PHP ファイルに `php-cs-fixer fix` と `phpcs` を実行
+- **pre-push**: `composer build`（csf + cs + sa + md）でフル静的解析
+
 ## 開発
 
 ```bash

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -1,0 +1,15 @@
+pre-commit:
+  parallel: true
+  commands:
+    php-cs-fixer:
+      glob: "*.php"
+      run: ./vendor/bin/php-cs-fixer fix {staged_files}
+      stage_fixed: true
+    phpcs:
+      glob: "*.php"
+      run: ./vendor/bin/phpcs --standard=phpcs.xml {staged_files}
+
+pre-push:
+  commands:
+    composer-build:
+      run: composer build


### PR DESCRIPTION
## Summary
- Add `lefthook.yml` to manage Git hooks with [Lefthook](https://github.com/evilmartians/lefthook)
- Documents one-time setup in README

## Hooks
| Hook | Commands | Purpose |
| --- | --- | --- |
| pre-commit | `php-cs-fixer fix` (staged, auto-restage) + `phpcs` (staged) | Catch and auto-fix style issues before commit |
| pre-push | `composer build` (csf + cs + sa + md) | Catch static analysis failures before they hit CI |

Pre-commit only runs against the staged files (fast). Pre-push runs full `composer build` which is heavier (~10-30s) but mirrors what CI does.

## One-time setup (per clone)
```bash
brew install lefthook    # if not installed
lefthook install         # registers hooks in .git/hooks
```

`brew install lefthook` was added to the personal mac_setup script (out of repo).

## Why pre-commit only auto-fixes csf, not cs
- `php-cs-fixer` is deterministic and safe to auto-apply.
- `phpcs` is left as a check (no `phpcbf`) to surface stylistic issues for human review rather than silently rewriting.

## Test plan
- [ ] Run `lefthook install` after merge
- [ ] Stage a PHP file with formatting issues, commit -> php-cs-fixer auto-fixes and restages
- [ ] Stage a PHP file with phpcs violation -> commit blocked
- [ ] Push a branch with PHPStan failure -> push blocked

🤖 Generated with [Claude Code](https://claude.com/claude-code)