### PR TITLE
chore: group dependabot github-actions minor/patch updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -44,3 +44,8 @@ updates:
     labels:
       - dependencies
       - github-actions
+    groups:
+      actions-minor-and-patch:
+        update-types:
+          - minor
+          - patch


### PR DESCRIPTION
## Summary
- GitHub Actions の minor/patch 更新を 1 つの PR にまとめて Dependabot のノイズを削減
- 既存の composer / npm のグルーピング設定と同じパターンを踏襲
- major 更新は引き続き個別 PR

## Test plan
- [ ] 次回月曜のスケジュール実行で actions の grouped PR が生成されることを確認
- [ ] CI が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)