### PR TITLE
ci: add codecov.yml with coverage gating

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,30 @@
+coverage:
+  status:
+    project:
+      default:
+        target: auto
+        threshold: 1%
+        if_ci_failed: error
+    patch:
+      default:
+        target: 80%
+        threshold: 0%
+        if_ci_failed: error
+
+comment:
+  layout: "diff, flags, files"
+  behavior: default
+  require_changes: false
+
+ignore:
+  - "tests"
+  - "database/migrations"
+  - "database/seeders"
+  - "database/factories"
+  - "config"
+  - "bootstrap"
+  - "public"
+  - "resources"
+  - "routes"
+  - "storage"
+  - "vendor"


### PR DESCRIPTION
## Summary
- カバレッジが大きく下がったら CI を落とすため codecov.yml を追加
- project: auto target、1% の下振れ許容（誤差吸収）
- patch: 変更行に対して 80% カバレッジ要求
- アプリ外ディレクトリ（tests / migrations / config / vendor 等）は ignore

## Test plan
- [ ] CI が通る
- [ ] codecov/project と codecov/patch のステータスチェックが PR に表示される

🤖 Generated with [Claude Code](https://claude.com/claude-code)