### PR TITLE
chore: route lefthook hooks through Laravel Sail

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,25 +20,49 @@ Laravel をベースにしたユーザー管理アプリケーションのプラ
 
 ## セットアップ
 
+ローカルに PHP / composer / Node を入れる必要はありません。Docker（Docker Desktop / OrbStack 等）だけ用意してください。
+
 ```bash
-composer install
-npm install
+# 1. 依存をインストール（PHP/composer をコンテナで実行）
+docker run --rm \
+  -v "$(pwd):/var/www/html" \
+  -w /var/www/html \
+  laravelsail/php84-composer:latest \
+  composer install --ignore-platform-reqs
+
+# 2. 環境ファイルをコピー
 cp .env.example .env
-php artisan key:generate
-php artisan migrate
+
+# 3. Sail 起動（PHP / MySQL / Redis のコンテナ群を立ち上げ）
+./vendor/bin/sail up -d
+
+# 4. コンテナ内でアプリ初期化
+./vendor/bin/sail artisan key:generate
+./vendor/bin/sail artisan migrate
+./vendor/bin/sail npm install
+```
+
+以降は `./vendor/bin/sail <cmd>` で各種ツールを実行できます。よく使うエイリアスを `~/.zshrc` に入れておくと楽です。
+
+```bash
+alias sail='[ -f sail ] && sh sail || sh vendor/bin/sail'
 ```
 
 ### Git フック (Lefthook)
 
-`lefthook.yml` で pre-commit / pre-push フックを管理しています。初回のみ以下を実行してください。
+`lefthook.yml` で pre-commit / pre-push フックを管理しています。フック内のコマンドはすべて Sail 経由でコンテナ内実行されるため、ローカルに PHP は不要です（コンテナが起動している必要はあります）。
+
+初回のみ:
 
 ```bash
 brew install lefthook    # 未導入の場合
 lefthook install         # .git/hooks にフックを登録
 ```
 
-- **pre-commit**: ステージ済み PHP ファイルに `php-cs-fixer fix` と `phpcs` を実行
-- **pre-push**: `composer build`（csf + cs + sa + md）でフル静的解析
+- **pre-commit**: ステージ済み PHP ファイルに `sail bin php-cs-fixer fix` と `sail bin phpcs` を実行
+- **pre-push**: `sail composer build`（csf + cs + sa + md）でフル静的解析
+
+> フック実行前に `./vendor/bin/sail up -d` でコンテナを起動しておいてください。停止中だとフックが失敗します。
 
 ## 開発
 

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,13 +3,13 @@ pre-commit:
   commands:
     php-cs-fixer:
       glob: "*.php"
-      run: ./vendor/bin/php-cs-fixer fix {staged_files}
+      run: ./vendor/bin/sail bin php-cs-fixer fix {staged_files}
       stage_fixed: true
     phpcs:
       glob: "*.php"
-      run: ./vendor/bin/phpcs --standard=phpcs.xml {staged_files}
+      run: ./vendor/bin/sail bin phpcs --standard=phpcs.xml {staged_files}
 
 pre-push:
   commands:
     composer-build:
-      run: composer build
+      run: ./vendor/bin/sail composer build


### PR DESCRIPTION
## Summary
- Git フック（pre-commit / pre-push）を Sail コンテナ経由で実行するよう変更
- ローカルに PHP / composer / Node を入れずに開発できるようになる
- README セットアップ手順も Docker ベースに書き直し（`docker run laravelsail/php84-composer` で初回の composer install）

## Why
- 「ローカル環境を汚さず開発したい」というニーズに対応
- CI 環境とフック実行環境の差分を縮小（どちらも PHP 8.4 コンテナ）

## Test plan
- [x] pre-push が `sail composer build` を 4.89s で完走することを確認済み
- [ ] CI が通る
- [ ] README の手順を新規環境で試したい場合は別途検証

🤖 Generated with [Claude Code](https://claude.com/claude-code)