### PR TITLE
chore: ルート定義とセットアップ後の利便性を改善

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -61,8 +61,8 @@ setup: ## One-shot bootstrap (idempotent)
 		echo "==> generating APP_KEY for .env.testing"; \
 		$(SAIL) artisan key:generate --env=testing --force; \
 	fi
-	@echo "==> running migrations"
-	@$(SAIL) artisan migrate
+	@echo "==> running migrations & seeders"
+	@$(SAIL) artisan migrate --seed
 	@if [ ! -d node_modules ]; then \
 		echo "==> npm install"; \
 		$(SAIL) npm install; \
@@ -70,6 +70,11 @@ setup: ## One-shot bootstrap (idempotent)
 		echo "==> node_modules/ exists, skipping npm install"; \
 	fi
 	@echo "==> setup complete"
+	@echo ""
+	@echo "  App:        http://localhost"
+	@echo "  Admin:      http://localhost/admin"
+	@echo "  Login user: test_user@example.com / test1111"
+	@echo ""
 
 up: ## Start Sail containers
 	@$(SAIL) up -d

--- a/database/seeders/UserSeeder.php
+++ b/database/seeders/UserSeeder.php
@@ -15,10 +15,12 @@ class UserSeeder extends Seeder
      */
     public function run(): void
     {
-        User::factory()->create([
-            'name' => 'テストユーザー',
-            'email' => 'test_user@example.com',
-            'password' => Hash::make('test1111'),
-        ]);
+        User::firstOrCreate(
+            ['email' => 'test_user@example.com'],
+            [
+                'name' => 'テストユーザー',
+                'password' => Hash::make('test1111'),
+            ],
+        );
     }
 }

--- a/lefthook.yml
+++ b/lefthook.yml
@@ -3,7 +3,7 @@ pre-commit:
   commands:
     php-cs-fixer:
       glob: "*.php"
-      run: ./vendor/bin/sail bin php-cs-fixer fix {staged_files}
+      run: ./vendor/bin/sail bin php-cs-fixer fix --config=.php-cs-fixer.dist.php {staged_files}
       stage_fixed: true
     phpcs:
       glob: "*.php"

--- a/routes/web.php
+++ b/routes/web.php
@@ -1,14 +1,8 @@
 <?php declare(strict_types=1);
 
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 
-/*
-|--------------------------------------------------------------------------
-| Web Routes
-|--------------------------------------------------------------------------
-|
-| Here is where you can register web routes for your application. These
-| routes are loaded by the RouteServiceProvider within a group which
-| contains the "web" middleware group. Now create something great!
-|
-*/
+Route::get('/', static fn () => Auth::check()
+    ? redirect()->route('filament.admin.pages.dashboard')
+    : redirect()->route('filament.admin.auth.login'));


### PR DESCRIPTION
## Summary
- `/` アクセス時に認証状態に応じて Filament ダッシュボード or ログイン画面へリダイレクト（404 解消）
- `make setup` で `migrate --seed` を実行し、UserSeeder を `firstOrCreate` で冪等化
- セットアップ完了時にアクセス URL とテストユーザー認証情報を表示
- 複数ファイル commit 時に php-cs-fixer が \"For multiple paths config parameter is required\" で落ちる lefthook 設定を修正（`--config=.php-cs-fixer.dist.php` を明示）

## Test plan
- [x] `make setup` 実行 → URL/ログイン情報の表示を確認
- [x] `curl -I http://localhost/` → 302 で `/admin/login` にリダイレクトされる
- [x] `make build` (csf + cs + sa + md) オールクリア
- [x] 複数 PHP ファイルを含むコミットで pre-commit が通る

🤖 Generated with [Claude Code](https://claude.com/claude-code)