### PR TITLE
feat: Sanctum SPA 認証フロント (Next.js で User/Admin の 2 系統ログイン)

### DIFF
--- a/docs/evidence/sanctum-spa-auth-frontend/README.md
+++ b/docs/evidence/sanctum-spa-auth-frontend/README.md
@@ -1,0 +1,94 @@
+# PR 3: Sanctum SPA 認証 (フロント) 動作確認
+
+PR #75 で整備したバックエンド (Sanctum SPA + Multi-guard) を Next.js 側から消費する。User と Admin の 2 系統で、`/sanctum/csrf-cookie` → `/api/login` → `/api/me` → `/api/logout` を一通り通せることを確認する。
+
+## 環境
+
+- Laravel API: `http://localhost`
+- Next.js dev: `http://localhost:3000` (Sail コンテナ内 `next dev -H 0.0.0.0 -p 3000`)
+- DB: 既存の seed (`user@example.com`, `admin@example.com`、いずれもパスワード `password`)
+
+## 構成
+
+- 共通 axios クライアント `frontend/lib/api.ts`
+  - `withCredentials: true` / `withXSRFToken: true` / `xsrfCookieName: 'XSRF-TOKEN'` / `xsrfHeaderName: 'X-XSRF-TOKEN'`
+  - `ensureCsrfCookie()` で `/sanctum/csrf-cookie` を 1 度だけ発行
+- 認証フック `frontend/lib/auth.ts`
+  - `useUser()` / `useAdmin()` がそれぞれ `/api/me` / `/api/admin/me` を叩いて状態を返す
+  - `loginUser` / `loginAdmin` / `logoutUser` / `logoutAdmin` を export
+- フォーム共通コンポーネント `frontend/components/LoginForm.tsx`
+  - email / password / submit、サーバ側 `message` をエラー表示
+- 画面
+  - `/login` : User ログイン → 成功で `/me`
+  - `/admin/login` : Admin ログイン → 成功で `/admin/me`
+  - `/me` : User ダッシュボード (id / name / email + ログアウト)
+  - `/admin/me` : Admin ダッシュボード (id / name / email / role + ログアウト)
+  - `/` : health 表示 + 2 つのログイン入口
+
+## E2E ブラウザ確認
+
+Chrome (Claude in Chrome) で以下を確認した。PNG はプロジェクト方針で割愛し、`read_page` の DOM スナップショットで代替する。
+
+### 1. User ログイン → /me
+
+```
+form
+ heading "User ログイン"
+ label "Email" (textbox type=email)
+ label "Password" (textbox type=password)
+ button "Sign in"
+```
+
+`user@example.com` / `password` を入力 → 遷移先 `/me`:
+
+```
+main
+ heading "User ダッシュボード"
+ generic "name" / "Louvenia Zemlak"
+ generic "email" / "user@example.com"
+ button "ログアウト"
+```
+
+### 2. Admin ログイン → /admin/me
+
+`admin@example.com` / `password` を入力 → 遷移先 `/admin/me`:
+
+```
+main
+ heading "Admin ダッシュボード"
+ generic "name" / "Sterling Goyette"
+ generic "email" / "admin@example.com"
+ generic "role" / "system_admin"
+ button "ログアウト"
+```
+
+### 3. ログイン失敗
+
+`user@example.com` / `wrong-password` を `/login` に投入:
+
+```
+form
+ heading "User ログイン"
+ textbox "user@example.com"
+ textbox [value redacted]
+ alert "These credentials do not match our records."
+ button "Sign in"
+```
+
+サーバ側 (`AuthController::login` で `ValidationException`) のメッセージがそのまま画面に表示される。
+
+### 4. クロスガード分離
+
+User と Admin にそれぞれログインした状態で `/me` と `/admin/me` を行き来したところ、各画面が **対応する guard のデータをそれぞれ表示**することを確認した (web セッションと admin セッションが同時に存在しても、画面側のフックは自分用の guard だけを参照する)。
+
+## 自動チェック
+
+- `./vendor/bin/sail bash -c "cd frontend && npm run lint"` PASS (React 19 の `set-state-in-effect` 規則含む)
+- `./vendor/bin/sail bash -c "cd frontend && npm run build"` PASS
+- ルート: `/`, `/_not-found`, `/admin/login`, `/admin/me`, `/login`, `/me`
+
+## 後続 PR への申し送り
+
+- 本実装はまだログイン後ホームへの自動リダイレクトを行っていない (`/login` を直接踏むと既ログインでもログイン画面が出る)。オークション機能 (PR 6) を作る際にナビゲーションを整理する
+- React 19 の `set-state-in-effect` 規則のため、`useEffect` 内で setState は cancel フラグ + Promise 経由で行う形に統一した
+- axios の `withXSRFToken: true` と `withCredentials: true` を両方有効化することで CSRF cookie 同送が成立している

--- a/frontend/app/admin/login/page.tsx
+++ b/frontend/app/admin/login/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import LoginForm from '@/components/LoginForm';
+import { loginAdmin } from '@/lib/auth';
+
+export default function AdminLoginPage() {
+  const router = useRouter();
+
+  const handleSubmit = async (email: string, password: string) => {
+    await loginAdmin(email, password);
+    router.push('/admin/me');
+  };
+
+  return <LoginForm title="Admin ログイン" onSubmit={handleSubmit} />;
+}

--- a/frontend/app/admin/me/page.tsx
+++ b/frontend/app/admin/me/page.tsx
@@ -1,0 +1,54 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { logoutAdmin, useAdmin } from '@/lib/auth';
+
+export default function AdminDashboardPage() {
+  const router = useRouter();
+  const { auth } = useAdmin();
+
+  useEffect(() => {
+    if (auth.state === 'unauthenticated') {
+      router.replace('/admin/login');
+    }
+  }, [auth.state, router]);
+
+  if (auth.state !== 'authenticated') {
+    return (
+      <main className="flex min-h-screen items-center justify-center p-8">
+        <p className="text-zinc-600 dark:text-zinc-400">
+          {auth.state === 'loading' ? '読み込み中...' : 'ログインへ移動します...'}
+        </p>
+      </main>
+    );
+  }
+
+  const handleLogout = async () => {
+    await logoutAdmin();
+    router.push('/admin/login');
+  };
+
+  return (
+    <main className="mx-auto mt-16 flex w-full max-w-md flex-col gap-4 rounded-lg border border-zinc-300 bg-white p-8 shadow-sm dark:border-zinc-700 dark:bg-zinc-900">
+      <h1 className="text-2xl font-semibold">Admin ダッシュボード</h1>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+        <dt className="text-zinc-500">id</dt>
+        <dd>{auth.principal.id}</dd>
+        <dt className="text-zinc-500">name</dt>
+        <dd>{auth.principal.name}</dd>
+        <dt className="text-zinc-500">email</dt>
+        <dd>{auth.principal.email}</dd>
+        <dt className="text-zinc-500">role</dt>
+        <dd>{auth.principal.role}</dd>
+      </dl>
+      <button
+        type="button"
+        onClick={handleLogout}
+        className="mt-4 rounded border border-zinc-300 px-4 py-2 text-base font-medium dark:border-zinc-700"
+      >
+        ログアウト
+      </button>
+    </main>
+  );
+}

--- a/frontend/app/login/page.tsx
+++ b/frontend/app/login/page.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import LoginForm from '@/components/LoginForm';
+import { loginUser } from '@/lib/auth';
+
+export default function UserLoginPage() {
+  const router = useRouter();
+
+  const handleSubmit = async (email: string, password: string) => {
+    await loginUser(email, password);
+    router.push('/me');
+  };
+
+  return <LoginForm title="User ログイン" onSubmit={handleSubmit} />;
+}

--- a/frontend/app/me/page.tsx
+++ b/frontend/app/me/page.tsx
@@ -1,0 +1,52 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { useEffect } from 'react';
+import { logoutUser, useUser } from '@/lib/auth';
+
+export default function UserDashboardPage() {
+  const router = useRouter();
+  const { auth } = useUser();
+
+  useEffect(() => {
+    if (auth.state === 'unauthenticated') {
+      router.replace('/login');
+    }
+  }, [auth.state, router]);
+
+  if (auth.state !== 'authenticated') {
+    return (
+      <main className="flex min-h-screen items-center justify-center p-8">
+        <p className="text-zinc-600 dark:text-zinc-400">
+          {auth.state === 'loading' ? '読み込み中...' : 'ログインへ移動します...'}
+        </p>
+      </main>
+    );
+  }
+
+  const handleLogout = async () => {
+    await logoutUser();
+    router.push('/login');
+  };
+
+  return (
+    <main className="mx-auto mt-16 flex w-full max-w-md flex-col gap-4 rounded-lg border border-zinc-300 bg-white p-8 shadow-sm dark:border-zinc-700 dark:bg-zinc-900">
+      <h1 className="text-2xl font-semibold">User ダッシュボード</h1>
+      <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+        <dt className="text-zinc-500">id</dt>
+        <dd>{auth.principal.id}</dd>
+        <dt className="text-zinc-500">name</dt>
+        <dd>{auth.principal.name}</dd>
+        <dt className="text-zinc-500">email</dt>
+        <dd>{auth.principal.email}</dd>
+      </dl>
+      <button
+        type="button"
+        onClick={handleLogout}
+        className="mt-4 rounded border border-zinc-300 px-4 py-2 text-base font-medium dark:border-zinc-700"
+      >
+        ログアウト
+      </button>
+    </main>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import Link from 'next/link';
 import { useEffect, useState } from 'react';
 
 type HealthStatus =
@@ -30,6 +31,7 @@ export default function Home() {
   return (
     <main className="flex min-h-screen flex-col items-center justify-center gap-6 p-8">
       <h1 className="text-3xl font-bold">type89</h1>
+
       <section className="rounded-lg border border-zinc-300 bg-white p-6 shadow-sm dark:border-zinc-700 dark:bg-zinc-900">
         <h2 className="text-lg font-semibold">Laravel API health</h2>
         {health.state === 'loading' && (
@@ -41,11 +43,24 @@ export default function Home() {
           </p>
         )}
         {health.state === 'error' && (
-          <p className="mt-2 text-sm text-red-600 dark:text-red-400">
-            {health.message}
-          </p>
+          <p className="mt-2 text-sm text-red-600 dark:text-red-400">{health.message}</p>
         )}
       </section>
+
+      <nav className="flex gap-4 text-sm">
+        <Link
+          href="/login"
+          className="rounded border border-zinc-300 px-4 py-2 dark:border-zinc-700"
+        >
+          User ログイン
+        </Link>
+        <Link
+          href="/admin/login"
+          className="rounded border border-zinc-300 px-4 py-2 dark:border-zinc-700"
+        >
+          Admin ログイン
+        </Link>
+      </nav>
     </main>
   );
 }

--- a/frontend/components/LoginForm.tsx
+++ b/frontend/components/LoginForm.tsx
@@ -1,0 +1,97 @@
+'use client';
+
+import { FormEvent, useState } from 'react';
+
+type Props = {
+  title: string;
+  onSubmit: (email: string, password: string) => Promise<void>;
+};
+
+export default function LoginForm({ title, onSubmit }: Props) {
+  const [email, setEmail] = useState('');
+  const [password, setPassword] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setError(null);
+    setSubmitting(true);
+    try {
+      await onSubmit(email, password);
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'response' in err
+          ? extractErrorMessage(err)
+          : err instanceof Error
+            ? err.message
+            : 'Login failed';
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <form
+      onSubmit={handleSubmit}
+      className="mx-auto mt-16 flex w-full max-w-md flex-col gap-4 rounded-lg border border-zinc-300 bg-white p-8 shadow-sm dark:border-zinc-700 dark:bg-zinc-900"
+    >
+      <h1 className="text-2xl font-semibold">{title}</h1>
+
+      <label className="flex flex-col gap-1 text-sm">
+        Email
+        <input
+          type="email"
+          value={email}
+          onChange={(e) => setEmail(e.target.value)}
+          required
+          autoComplete="email"
+          className="rounded border border-zinc-300 bg-white px-3 py-2 text-base dark:border-zinc-700 dark:bg-zinc-950"
+        />
+      </label>
+
+      <label className="flex flex-col gap-1 text-sm">
+        Password
+        <input
+          type="password"
+          value={password}
+          onChange={(e) => setPassword(e.target.value)}
+          required
+          autoComplete="current-password"
+          className="rounded border border-zinc-300 bg-white px-3 py-2 text-base dark:border-zinc-700 dark:bg-zinc-950"
+        />
+      </label>
+
+      {error && (
+        <p className="text-sm text-red-600 dark:text-red-400" role="alert">
+          {error}
+        </p>
+      )}
+
+      <button
+        type="submit"
+        disabled={submitting}
+        className="mt-2 rounded bg-zinc-900 px-4 py-2 text-base font-medium text-white disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900"
+      >
+        {submitting ? 'Signing in…' : 'Sign in'}
+      </button>
+    </form>
+  );
+}
+
+const extractErrorMessage = (err: { response?: unknown }): string => {
+  const response = err.response;
+  if (
+    response &&
+    typeof response === 'object' &&
+    'data' in response &&
+    response.data &&
+    typeof response.data === 'object' &&
+    'message' in response.data &&
+    typeof response.data.message === 'string'
+  ) {
+    return response.data.message;
+  }
+  return 'Login failed';
+};

--- a/frontend/lib/api.ts
+++ b/frontend/lib/api.ts
@@ -1,0 +1,24 @@
+import axios, { AxiosInstance } from 'axios';
+
+const baseURL = process.env.NEXT_PUBLIC_API_URL ?? 'http://localhost';
+
+export const api: AxiosInstance = axios.create({
+  baseURL,
+  withCredentials: true,
+  withXSRFToken: true,
+  xsrfCookieName: 'XSRF-TOKEN',
+  xsrfHeaderName: 'X-XSRF-TOKEN',
+  headers: {
+    Accept: 'application/json',
+    'Content-Type': 'application/json',
+  },
+});
+
+let csrfPromise: Promise<void> | null = null;
+
+export const ensureCsrfCookie = (): Promise<void> => {
+  if (!csrfPromise) {
+    csrfPromise = api.get('/sanctum/csrf-cookie').then(() => undefined);
+  }
+  return csrfPromise;
+};

--- a/frontend/lib/auth.ts
+++ b/frontend/lib/auth.ts
@@ -1,0 +1,81 @@
+'use client';
+
+import { useCallback, useEffect, useState } from 'react';
+import { api, ensureCsrfCookie } from './api';
+
+export type User = {
+  id: number;
+  name: string;
+  email: string;
+};
+
+export type AdminRole = 'system_admin' | 'general_admin';
+
+export type Admin = {
+  id: number;
+  name: string;
+  email: string;
+  role: AdminRole;
+};
+
+export type AuthState<T> =
+  | { state: 'loading' }
+  | { state: 'authenticated'; principal: T }
+  | { state: 'unauthenticated' };
+
+const useAuthFor = <T>(meEndpoint: string): {
+  auth: AuthState<T>;
+  refresh: () => Promise<void>;
+} => {
+  const [auth, setAuth] = useState<AuthState<T>>({ state: 'loading' });
+
+  const fetchPrincipal = useCallback(async (): Promise<AuthState<T>> => {
+    try {
+      const response = await api.get<{ data: T }>(meEndpoint);
+      return { state: 'authenticated', principal: response.data.data };
+    } catch {
+      return { state: 'unauthenticated' };
+    }
+  }, [meEndpoint]);
+
+  const refresh = useCallback(async (): Promise<void> => {
+    setAuth(await fetchPrincipal());
+  }, [fetchPrincipal]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchPrincipal().then((next) => {
+      if (!cancelled) {
+        setAuth(next);
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [fetchPrincipal]);
+
+  return { auth, refresh };
+};
+
+export const useUser = () => useAuthFor<User>('/api/me');
+export const useAdmin = () => useAuthFor<Admin>('/api/admin/me');
+
+export const loginUser = async (email: string, password: string): Promise<User> => {
+  await ensureCsrfCookie();
+  const response = await api.post<{ data: User }>('/api/login', { email, password });
+  return response.data.data;
+};
+
+export const logoutUser = async (): Promise<void> => {
+  await api.post('/api/logout');
+};
+
+export const loginAdmin = async (email: string, password: string): Promise<Admin> => {
+  await ensureCsrfCookie();
+  const response = await api.post<{ data: Admin }>('/api/admin/login', { email, password });
+  return response.data.data;
+};
+
+export const logoutAdmin = async (): Promise<void> => {
+  await api.post('/api/admin/logout');
+};

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -8,6 +8,7 @@
       "name": "frontend",
       "version": "0.1.0",
       "dependencies": {
+        "axios": "^1.16.0",
         "next": "16.2.6",
         "react": "19.2.4",
         "react-dom": "19.2.4"
@@ -2499,6 +2500,12 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
+    },
     "node_modules/available-typed-arrays": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/available-typed-arrays/-/available-typed-arrays-1.0.7.tgz",
@@ -2523,6 +2530,17 @@
       "license": "MPL-2.0",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/axios": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.16.0.tgz",
+      "integrity": "sha512-6hp5CwvTPlN2A31g5dxnwAX0orzM7pmCRDLnZSX772mv8WDqICwFjowHuPs04Mc8deIld1+ejhtaMn5vp6b+1w==",
+      "license": "MIT",
+      "dependencies": {
+        "follow-redirects": "^1.16.0",
+        "form-data": "^4.0.5",
+        "proxy-from-env": "^2.1.0"
       }
     },
     "node_modules/axobject-query": {
@@ -2635,7 +2653,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
       "integrity": "sha512-Sp1ablJ0ivDkSzjcaJdxEunN5/XvksFJ2sMBFfq6x0ryhQV/2b/KwFe21cMpmHtPOSij8K99/wSfoEuTObmuMQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -2734,6 +2751,18 @@
       "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
     },
     "node_modules/concat-map": {
       "version": "0.0.1",
@@ -2893,6 +2922,15 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2920,7 +2958,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/dunder-proto/-/dunder-proto-1.0.1.tgz",
       "integrity": "sha512-KIN/nDJBQRcXw0MLVhZE9iQHmG68qAVIBg9CqmUYjmQIhgij9U5MFvrqkUL5FbtyyzZuOeOt0zdeRe4UY7ct+A==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.1",
@@ -3032,7 +3069,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
       "integrity": "sha512-e3nRfgfUZ4rNGL232gUgX06QNyyez04KdjFrF+LTRoOXmrOgFKDg4BCdsjW8EnT69eqdYGmRpJwiPVYNrCaW3g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3042,7 +3078,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/es-errors/-/es-errors-1.3.0.tgz",
       "integrity": "sha512-Zf5H2Kxt2xjTvbJvP2ZWLEICxA6j+hAmMzIlypy4xcBg1vKVnx89Wy0GbS+kf5cwCVFFzdCFh2XSCFNULS6csw==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3080,7 +3115,6 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-object-atoms/-/es-object-atoms-1.1.1.tgz",
       "integrity": "sha512-FGgH2h8zKNim9ljj7dankFPcICIK9Cp5bm+c2gQSYePhpaG5+esrLODihIorn+Pe6FGJzWhXQotPv73jTaldXA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0"
@@ -3093,7 +3127,6 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
       "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "es-errors": "^1.3.0",
@@ -3690,6 +3723,26 @@
       "dev": true,
       "license": "ISC"
     },
+    "node_modules/follow-redirects": {
+      "version": "1.16.0",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.16.0.tgz",
+      "integrity": "sha512-y5rN/uOsadFT/JfYwhxRS5R7Qce+g3zG97+JrtFZlC9klX/W5hD7iiLzScI4nZqUS7DNUdhPgw4xI8W2LuXlUw==",
+      "funding": [
+        {
+          "type": "individual",
+          "url": "https://github.com/sponsors/RubenVerborgh"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=4.0"
+      },
+      "peerDependenciesMeta": {
+        "debug": {
+          "optional": true
+        }
+      }
+    },
     "node_modules/for-each": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/for-each/-/for-each-0.3.5.tgz",
@@ -3706,11 +3759,26 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
     "node_modules/function-bind": {
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/function-bind/-/function-bind-1.1.2.tgz",
       "integrity": "sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==",
-      "dev": true,
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
@@ -3771,7 +3839,6 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.3.0.tgz",
       "integrity": "sha512-9fSjSaos/fRIVIp+xSJlE6lfwhES7LNtKaCBIamHsjr2na1BiABJPo0mOjjz8GJDURarmCPGqaiVg5mfjb98CQ==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "call-bind-apply-helpers": "^1.0.2",
@@ -3796,7 +3863,6 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/get-proto/-/get-proto-1.0.1.tgz",
       "integrity": "sha512-sTSfBjoXBp89JvIKIefqw7U2CCebsc74kiY6awiGogKtoSGbgjYE/G/+l9sF3MWFPNc9IcoOC4ODfKHfxFmp0g==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "dunder-proto": "^1.0.1",
@@ -3884,7 +3950,6 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.2.0.tgz",
       "integrity": "sha512-ZUKRh6/kUFoAiTAtTYPZJ3hw9wNxx+BIBOijnlG9PnrJsCcSjs1wyyD6vJpaYtgnzDrKYRSqf3OO6Rfa93xsRg==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3956,7 +4021,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -3969,7 +4033,6 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
       "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "has-symbols": "^1.0.3"
@@ -3985,7 +4048,6 @@
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.3.tgz",
       "integrity": "sha512-ej4AhfhfL2Q2zpMmLo7U1Uv9+PyhIZpgQLGT1F9miIGmiCJIoCgSmczFdrc97mWT4kVY72KA+WnnhJ5pghSvSg==",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "function-bind": "^1.1.2"
@@ -4980,7 +5042,6 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/math-intrinsics/-/math-intrinsics-1.1.0.tgz",
       "integrity": "sha512-/IXtbwEk5HTPyEwyKX6hGkYXxM9nbj64B+ilVJnC/R6B0pH5G4V3b0pVbL7DBj4tkhBAppbQUlf6F6Xl9LHu1g==",
-      "dev": true,
       "license": "MIT",
       "engines": {
         "node": ">= 0.4"
@@ -5008,6 +5069,27 @@
       },
       "engines": {
         "node": ">=8.6"
+      }
+    },
+    "node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
       }
     },
     "node_modules/minimatch": {
@@ -5497,6 +5579,15 @@
         "loose-envify": "^1.4.0",
         "object-assign": "^4.1.1",
         "react-is": "^16.13.1"
+      }
+    },
+    "node_modules/proxy-from-env": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-2.1.0.tgz",
+      "integrity": "sha512-cJ+oHTW1VAEa8cJslgmUZrc+sjRKgAKl3Zyse6+PV38hZe/V6Z14TbCuXcan9F9ghlz4QrFr2c92TNF82UkYHA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
       }
     },
     "node_modules/punycode": {

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -9,6 +9,7 @@
     "lint": "eslint"
   },
   "dependencies": {
+    "axios": "^1.16.0",
     "next": "16.2.6",
     "react": "19.2.4",
     "react-dom": "19.2.4"


### PR DESCRIPTION
## 背景

PR #75 で整備した Multi-guard Sanctum SPA 認証バックエンドを Next.js から消費する。User と Admin の 2 系統で `/sanctum/csrf-cookie` → `/api/login` → `/api/me` → `/api/logout` の一連を画面から通せるようにする。

## 変更内容

### 共通基盤 (\`frontend/lib/\`)
- \`api.ts\`: axios クライアント
  - \`withCredentials: true\` + \`withXSRFToken: true\` で cookie / XSRF を自動付与
  - \`xsrfCookieName: 'XSRF-TOKEN'\`, \`xsrfHeaderName: 'X-XSRF-TOKEN'\`
  - \`ensureCsrfCookie()\`: \`/sanctum/csrf-cookie\` を 1 度だけ叩いてセッションを初期化
- \`auth.ts\`: 認証フックと API ラッパ
  - \`useUser()\` / \`useAdmin()\`: \`/api/me\` / \`/api/admin/me\` を叩いて \`AuthState\` を返す
  - \`loginUser\` / \`loginAdmin\` / \`logoutUser\` / \`logoutAdmin\`
  - React 19 の \`react-hooks/set-state-in-effect\` 規則に合わせて, \`useEffect\` 内は cancel フラグ + Promise で setState を非同期に実行

### コンポーネント / ページ
- \`components/LoginForm.tsx\`: email/password/submit、サーバ側 \`message\` をエラー表示
- \`app/login/page.tsx\`: User ログイン → 成功で \`/me\` に遷移
- \`app/admin/login/page.tsx\`: Admin ログイン → 成功で \`/admin/me\` に遷移
- \`app/me/page.tsx\`: User ダッシュボード (id / name / email + ログアウト)
- \`app/admin/me/page.tsx\`: Admin ダッシュボード (id / name / email / role + ログアウト)
- \`app/page.tsx\`: ホームに 2 系統ログインへのリンクを追加

### 依存
- \`axios\` を追加

## 動作確認

\`docs/evidence/sanctum-spa-auth-frontend/README.md\` に詳細。Chrome (Claude in Chrome) で:

1. \`/login\` で \`user@example.com\` / \`password\` → \`/me\` に遷移し \`User ダッシュボード\` 表示
2. \`/admin/login\` で \`admin@example.com\` / \`password\` → \`/admin/me\` に遷移し \`role: system_admin\` を含めた管理者情報を表示
3. パスワード誤入力時に \`These credentials do not match our records.\` を画面に表示 (サーバ側 \`ValidationException\` の \`message\` をそのまま表示)
4. User と Admin に同時ログインしても、\`/me\` と \`/admin/me\` がそれぞれの guard データを正しく表示

\`npm run lint\` と \`npm run build\` (Next.js 16 / Turbopack) は CI でも PASS する想定。

## 後続 PR

- PR 4: Reverb (laravel/reverb + Echo + pusher-js)
- PR 5: オークション API + Broadcast
- PR 6: オークション UI

🤖 Generated with [Claude Code](https://claude.com/claude-code)