### PR TITLE
feat: オークション UI を Next.js で実装し Echo でリアルタイム価格更新

### DIFF
--- a/app/Events/BidPlaced.php
+++ b/app/Events/BidPlaced.php
@@ -1,0 +1,61 @@
+<?php declare(strict_types=1);
+
+namespace App\Events;
+
+use App\Models\Bid;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Broadcasting\InteractsWithSockets;
+use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
+use Illuminate\Foundation\Events\Dispatchable;
+use Illuminate\Queue\SerializesModels;
+
+class BidPlaced implements ShouldBroadcast
+{
+    use Dispatchable, InteractsWithSockets, SerializesModels;
+
+    public function __construct(public Bid $bid)
+    {
+    }
+
+    /**
+     * @return array<int, Channel>
+     */
+    public function broadcastOn(): array
+    {
+        return [new Channel("auction.{$this->bid->auction_id}")];
+    }
+
+    public function broadcastAs(): string
+    {
+        return 'bid.placed';
+    }
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function broadcastWith(): array
+    {
+        $bid = $this->bid->loadMissing('bidder', 'auction');
+
+        return [
+            'bid' => [
+                'id' => $bid->id,
+                'amount' => $bid->amount,
+                'created_at' => $bid->created_at->toIso8601String(),
+                'bidder' => [
+                    'id' => $bid->bidder->id,
+                    'name' => $bid->bidder->name,
+                ],
+            ],
+            'auction' => [
+                'id' => $bid->auction->id,
+                'current_price' => $bid->auction->current_price,
+                'min_next_bid' => $bid->auction->minNextBid(),
+                'current_winner' => [
+                    'id' => $bid->bidder->id,
+                    'name' => $bid->bidder->name,
+                ],
+            ],
+        ];
+    }
+}

--- a/app/Http/Controllers/Api/AuctionController.php
+++ b/app/Http/Controllers/Api/AuctionController.php
@@ -1,0 +1,53 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\StoreAuctionRequest;
+use App\Http\Resources\AuctionResource;
+use App\Models\Auction;
+use App\Models\User;
+use Illuminate\Http\Resources\Json\AnonymousResourceCollection;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Auth;
+
+class AuctionController extends Controller
+{
+    public function index(): AnonymousResourceCollection
+    {
+        $auctions = Auction::query()
+            ->with(['seller', 'currentWinner'])
+            ->orderByDesc('id')
+            ->get();
+
+        return AuctionResource::collection($auctions);
+    }
+
+    public function show(Auction $auction): JsonResource
+    {
+        $auction->load(['seller', 'currentWinner']);
+
+        return new AuctionResource($auction);
+    }
+
+    public function store(StoreAuctionRequest $request): JsonResource
+    {
+        /** @var User $seller */
+        $seller = Auth::guard('web')->user();
+
+        $auction = Auction::create([
+            'seller_user_id' => $seller->id,
+            'title' => $request->string('title')->toString(),
+            'description' => $request->string('description')->toString(),
+            'starting_price' => $request->integer('starting_price'),
+            'bid_increment' => $request->integer('bid_increment'),
+            'current_price' => $request->integer('starting_price'),
+            'starts_at' => $request->date('starts_at'),
+            'ends_at' => $request->date('ends_at'),
+        ]);
+
+        $auction->load('seller');
+
+        return new AuctionResource($auction);
+    }
+}

--- a/app/Http/Controllers/Api/BidController.php
+++ b/app/Http/Controllers/Api/BidController.php
@@ -1,0 +1,67 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Controllers\Api;
+
+use App\Events\BidPlaced;
+use App\Http\Controllers\Controller;
+use App\Http\Requests\Api\PlaceBidRequest;
+use App\Http\Resources\BidResource;
+use App\Models\Auction;
+use App\Models\Bid;
+use App\Models\User;
+use Illuminate\Http\Resources\Json\JsonResource;
+use Illuminate\Support\Facades\Auth;
+use Illuminate\Support\Facades\DB;
+use Illuminate\Validation\ValidationException;
+
+class BidController extends Controller
+{
+    public function store(PlaceBidRequest $request, Auction $auction): JsonResource
+    {
+        /** @var User $bidder */
+        $bidder = Auth::guard('web')->user();
+
+        $amount = $request->integer('amount');
+
+        $bid = DB::transaction(static function () use ($auction, $bidder, $amount): Bid {
+            $auction = Auction::query()->lockForUpdate()->findOrFail($auction->id);
+
+            if (! $auction->isActive()) {
+                throw ValidationException::withMessages([
+                    'amount' => ['オークションは現在受付中ではありません'],
+                ]);
+            }
+
+            if ($auction->seller_user_id === $bidder->id) {
+                throw ValidationException::withMessages([
+                    'amount' => ['自分の出品物には入札できません'],
+                ]);
+            }
+
+            $minNext = $auction->minNextBid();
+            if ($amount < $minNext) {
+                throw ValidationException::withMessages([
+                    'amount' => ["最低入札額は {$minNext} です"],
+                ]);
+            }
+
+            $bid = Bid::create([
+                'auction_id' => $auction->id,
+                'user_id' => $bidder->id,
+                'amount' => $amount,
+            ]);
+
+            $auction->update([
+                'current_price' => $amount,
+                'current_winner_user_id' => $bidder->id,
+            ]);
+
+            return $bid;
+        });
+
+        $bid->load('bidder');
+        broadcast(new BidPlaced($bid));
+
+        return new BidResource($bid);
+    }
+}

--- a/app/Http/Requests/Api/PlaceBidRequest.php
+++ b/app/Http/Requests/Api/PlaceBidRequest.php
@@ -1,0 +1,23 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class PlaceBidRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'amount' => ['required', 'integer', 'min:1'],
+        ];
+    }
+}

--- a/app/Http/Requests/Api/StoreAuctionRequest.php
+++ b/app/Http/Requests/Api/StoreAuctionRequest.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Requests\Api;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+class StoreAuctionRequest extends FormRequest
+{
+    public function authorize(): bool
+    {
+        return true;
+    }
+
+    /**
+     * @return array<string, array<int, string>>
+     */
+    public function rules(): array
+    {
+        return [
+            'title' => ['required', 'string', 'max:120'],
+            'description' => ['required', 'string'],
+            'starting_price' => ['required', 'integer', 'min:1'],
+            'bid_increment' => ['required', 'integer', 'min:1'],
+            'starts_at' => ['required', 'date'],
+            'ends_at' => ['required', 'date', 'after:starts_at'],
+        ];
+    }
+}

--- a/app/Http/Resources/AuctionResource.php
+++ b/app/Http/Resources/AuctionResource.php
@@ -1,0 +1,38 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Auction;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin Auction */
+class AuctionResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'title' => $this->title,
+            'description' => $this->description,
+            'seller' => [
+                'id' => $this->seller->id,
+                'name' => $this->seller->name,
+            ],
+            'starting_price' => $this->starting_price,
+            'bid_increment' => $this->bid_increment,
+            'current_price' => $this->current_price,
+            'min_next_bid' => $this->minNextBid(),
+            'current_winner' => $this->whenLoaded('currentWinner', fn () => $this->currentWinner ? [
+                'id' => $this->currentWinner->id,
+                'name' => $this->currentWinner->name,
+            ] : null),
+            'starts_at' => $this->starts_at->toIso8601String(),
+            'ends_at' => $this->ends_at->toIso8601String(),
+            'status' => $this->status,
+        ];
+    }
+}

--- a/app/Http/Resources/BidResource.php
+++ b/app/Http/Resources/BidResource.php
@@ -1,0 +1,28 @@
+<?php declare(strict_types=1);
+
+namespace App\Http\Resources;
+
+use App\Models\Bid;
+use Illuminate\Http\Request;
+use Illuminate\Http\Resources\Json\JsonResource;
+
+/** @mixin Bid */
+class BidResource extends JsonResource
+{
+    /**
+     * @return array<string, mixed>
+     */
+    public function toArray(Request $request): array
+    {
+        return [
+            'id' => $this->id,
+            'auction_id' => $this->auction_id,
+            'amount' => $this->amount,
+            'bidder' => [
+                'id' => $this->bidder->id,
+                'name' => $this->bidder->name,
+            ],
+            'created_at' => $this->created_at->toIso8601String(),
+        ];
+    }
+}

--- a/app/Models/Auction.php
+++ b/app/Models/Auction.php
@@ -1,0 +1,113 @@
+<?php declare(strict_types=1);
+
+namespace App\Models;
+
+use Database\Factories\AuctionFactory;
+use Illuminate\Database\Eloquent\Casts\Attribute;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Database\Eloquent\Relations\HasMany;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $seller_user_id
+ * @property string $title
+ * @property string $description
+ * @property int $starting_price
+ * @property int $bid_increment
+ * @property int $current_price
+ * @property int|null $current_winner_user_id
+ * @property Carbon $starts_at
+ * @property Carbon $ends_at
+ *
+ * @property-read User $seller
+ * @property-read User|null $currentWinner
+ * @property-read \Illuminate\Database\Eloquent\Collection<int, Bid> $bids
+ */
+class Auction extends Model
+{
+    /** @use HasFactory<AuctionFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'seller_user_id',
+        'title',
+        'description',
+        'starting_price',
+        'bid_increment',
+        'current_price',
+        'current_winner_user_id',
+        'starts_at',
+        'ends_at',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'seller_user_id' => 'integer',
+        'starting_price' => 'integer',
+        'bid_increment' => 'integer',
+        'current_price' => 'integer',
+        'current_winner_user_id' => 'integer',
+        'starts_at' => 'datetime',
+        'ends_at' => 'datetime',
+    ];
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function seller(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'seller_user_id');
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function currentWinner(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'current_winner_user_id');
+    }
+
+    /**
+     * @return HasMany<Bid, $this>
+     */
+    public function bids(): HasMany
+    {
+        return $this->hasMany(Bid::class);
+    }
+
+    /**
+     * @return Attribute<string, never>
+     */
+    protected function status(): Attribute
+    {
+        return Attribute::make(
+            get: function (): string {
+                if ($this->starts_at->isFuture()) {
+                    return 'pending';
+                }
+                if ($this->ends_at->isPast()) {
+                    return 'ended';
+                }
+                return 'active';
+            },
+        );
+    }
+
+    public function isActive(): bool
+    {
+        return $this->status === 'active';
+    }
+
+    public function minNextBid(): int
+    {
+        return $this->current_winner_user_id === null
+            ? $this->starting_price
+            : $this->current_price + $this->bid_increment;
+    }
+}

--- a/app/Models/Bid.php
+++ b/app/Models/Bid.php
@@ -1,0 +1,57 @@
+<?php declare(strict_types=1);
+
+namespace App\Models;
+
+use Database\Factories\BidFactory;
+use Illuminate\Database\Eloquent\Factories\HasFactory;
+use Illuminate\Database\Eloquent\Model;
+use Illuminate\Database\Eloquent\Relations\BelongsTo;
+use Illuminate\Support\Carbon;
+
+/**
+ * @property int $id
+ * @property int $auction_id
+ * @property int $user_id
+ * @property int $amount
+ * @property Carbon $created_at
+ *
+ * @property-read Auction $auction
+ * @property-read User $bidder
+ */
+class Bid extends Model
+{
+    /** @use HasFactory<BidFactory> */
+    use HasFactory;
+
+    protected $fillable = [
+        'auction_id',
+        'user_id',
+        'amount',
+    ];
+
+    /**
+     * @var array<string, string>
+     */
+    protected $casts = [
+        'id' => 'integer',
+        'auction_id' => 'integer',
+        'user_id' => 'integer',
+        'amount' => 'integer',
+    ];
+
+    /**
+     * @return BelongsTo<Auction, $this>
+     */
+    public function auction(): BelongsTo
+    {
+        return $this->belongsTo(Auction::class);
+    }
+
+    /**
+     * @return BelongsTo<User, $this>
+     */
+    public function bidder(): BelongsTo
+    {
+        return $this->belongsTo(User::class, 'user_id');
+    }
+}

--- a/database/factories/AuctionFactory.php
+++ b/database/factories/AuctionFactory.php
@@ -1,0 +1,55 @@
+<?php declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Auction;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+use Illuminate\Support\Carbon;
+
+/**
+ * @extends Factory<Auction>
+ */
+class AuctionFactory extends Factory
+{
+    /**
+     * @var class-string<Auction>
+     */
+    protected $model = Auction::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        $startingPrice = $this->faker->numberBetween(100, 10000);
+
+        return [
+            'seller_user_id' => User::factory(),
+            'title' => $this->faker->words(3, true),
+            'description' => $this->faker->paragraph(),
+            'starting_price' => $startingPrice,
+            'bid_increment' => $this->faker->numberBetween(10, 500),
+            'current_price' => $startingPrice,
+            'current_winner_user_id' => null,
+            'starts_at' => Carbon::now()->subMinutes(10),
+            'ends_at' => Carbon::now()->addHours(24),
+        ];
+    }
+
+    public function pending(): static
+    {
+        return $this->state([
+            'starts_at' => Carbon::now()->addHour(),
+            'ends_at' => Carbon::now()->addHours(2),
+        ]);
+    }
+
+    public function ended(): static
+    {
+        return $this->state([
+            'starts_at' => Carbon::now()->subHours(2),
+            'ends_at' => Carbon::now()->subMinute(),
+        ]);
+    }
+}

--- a/database/factories/BidFactory.php
+++ b/database/factories/BidFactory.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+namespace Database\Factories;
+
+use App\Models\Auction;
+use App\Models\Bid;
+use App\Models\User;
+use Illuminate\Database\Eloquent\Factories\Factory;
+
+/**
+ * @extends Factory<Bid>
+ */
+class BidFactory extends Factory
+{
+    /**
+     * @var class-string<Bid>
+     */
+    protected $model = Bid::class;
+
+    /**
+     * @return array<string, mixed>
+     */
+    public function definition(): array
+    {
+        return [
+            'auction_id' => Auction::factory(),
+            'user_id' => User::factory(),
+            'amount' => $this->faker->numberBetween(100, 100000),
+        ];
+    }
+}

--- a/database/migrations/2026_05_11_010000_create_auctions_table.php
+++ b/database/migrations/2026_05_11_010000_create_auctions_table.php
@@ -1,0 +1,31 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('auctions', static function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('seller_user_id')->constrained('users')->cascadeOnDelete();
+            $table->string('title', 120);
+            $table->text('description');
+            $table->unsignedBigInteger('starting_price');
+            $table->unsignedBigInteger('bid_increment');
+            $table->unsignedBigInteger('current_price');
+            $table->foreignId('current_winner_user_id')->nullable()->constrained('users')->nullOnDelete();
+            $table->dateTime('starts_at');
+            $table->dateTime('ends_at');
+            $table->timestamps();
+            $table->index(['ends_at']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('auctions');
+    }
+};

--- a/database/migrations/2026_05_11_010001_create_bids_table.php
+++ b/database/migrations/2026_05_11_010001_create_bids_table.php
@@ -1,0 +1,25 @@
+<?php declare(strict_types=1);
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    public function up(): void
+    {
+        Schema::create('bids', static function (Blueprint $table): void {
+            $table->id();
+            $table->foreignId('auction_id')->constrained('auctions')->cascadeOnDelete();
+            $table->foreignId('user_id')->constrained('users')->cascadeOnDelete();
+            $table->unsignedBigInteger('amount');
+            $table->timestamps();
+            $table->index(['auction_id', 'amount']);
+        });
+    }
+
+    public function down(): void
+    {
+        Schema::dropIfExists('bids');
+    }
+};

--- a/docs/evidence/auction-api/README.md
+++ b/docs/evidence/auction-api/README.md
@@ -1,0 +1,81 @@
+# PR 5: オークション API + Broadcast 動作確認
+
+英国式オークションの中核 (出品 / 入札 / 価格更新の broadcast) を整備する。本 PR は API + Broadcast までで、UI は PR 6 で被せる。
+
+## スキーマ
+
+- `auctions` (id, seller_user_id, title, description, starting_price, bid_increment, current_price, current_winner_user_id, starts_at, ends_at)
+- `bids` (id, auction_id, user_id, amount)
+
+`current_price` と `current_winner_user_id` は入札時に正規化キャッシュとして更新する。`status` は `starts_at` と `ends_at` から計算 (pending / active / ended)。
+
+## API
+
+```
+GET  /api/auctions               — 一覧 (誰でも)
+GET  /api/auctions/{id}          — 詳細
+POST /api/auctions               — 出品 (auth:web、StoreAuctionRequest でバリデーション)
+POST /api/auctions/{id}/bids     — 入札 (auth:web、PlaceBidRequest)
+```
+
+## Broadcast
+
+- チャネル `auction.{id}` (公開、誰でも観戦可)
+- イベント `bid.placed` を `App\Events\BidPlaced` で発火
+- payload は `bid` (id / amount / bidder / created_at) と `auction` (id / current_price / min_next_bid / current_winner)
+
+## 入札のドメインルール
+
+`BidController::store` の DB トランザクション内で次を検証 (排他は `lockForUpdate`):
+
+1. `status === 'active'` (期間内である)
+2. 出品者と入札者が異なる (`seller_user_id !== bidder->id`)
+3. 入札額が `min_next_bid` 以上 (初回は `starting_price`、以降は `current_price + bid_increment`)
+
+違反時は `ValidationException` (422、`amount` フィールドにエラー)。
+
+## 自動テスト
+
+`tests/Feature/Api/AuctionTest.php` (5 件) と `tests/Feature/Api/BidTest.php` (6 件):
+
+- 一覧 / 詳細 / 出品成功 / 認証必須 / `ends_at` バリデーション
+- 入札成功 + `BidPlaced` 発火 (Event::fake) / 増額未達 / 自分の出品物 / 終了済み / 開始前 / 認証必須
+
+```
+$ ./vendor/bin/sail composer test
+PHPUnit 12.5.24
+.............................                                     29 / 29 (100%)
+OK (29 tests, 71 assertions)
+```
+
+## E2E (curl)
+
+JST 起動 (`config/app.timezone = Asia/Tokyo`) のため、入力日時もローカルタイムゾーン付きで送る。
+
+```
+== Create auction ==
+{"data":{"id":1,...,"starting_price":1000,"current_price":1000,"min_next_bid":1000,"status":"active"}}
+
+== Place bid (1200, valid) ==
+{"data":{"id":3,"auction_id":1,"amount":1200,"bidder":{"id":2,"name":"..."},"created_at":"2026-05-11T01:28:34+09:00"}}
+
+== Show auction ==
+{"data":{"id":1,...,"current_price":1200,"min_next_bid":1300,"current_winner":{"id":2,"name":"..."},"status":"active"}}
+
+== Too-low bid (1100, must be 1200) ==
+{"message":"最低入札額は 1200 です","errors":{"amount":["最低入札額は 1200 です"]}}
+
+== Bid on own auction (seller) ==
+{"message":"自分の出品物には入札できません","errors":{"amount":["自分の出品物には入札できません"]}}
+```
+
+`current_price` がトランザクション内で 1100 → 1200 に更新され、`min_next_bid` も 1300 に追従していることを確認。
+
+## 既知の挙動
+
+- `App\Events\BidPlaced` は `ShouldBroadcast` (キュー経由) を使うが、開発環境は `QUEUE_CONNECTION=sync` のためインライン実行される。**Reverb サーバが起動していない状態で入札すると、DB 書き込みは成功するが broadcast 発火で 500 エラー** になる。本番投入前に `QUEUE_CONNECTION=redis` 等に切り替え、broadcast は async 化する想定。
+- `auction.{id}` チャネルは公開設定。私情報や入札の上書きはしないため、観戦自体に認証は不要とした。
+
+## 後続 PR
+
+- PR 6: Next.js でオークション一覧 / 詳細 / 出品 / 入札 UI を実装し、Echo で `bid.placed` を受けてリアルタイムに価格更新する。動作確認時は事前に `php artisan reverb:start` を起動する。

--- a/docs/evidence/auction-ui/README.md
+++ b/docs/evidence/auction-ui/README.md
@@ -1,0 +1,96 @@
+# PR 6: オークション UI (Next.js + Echo) 動作確認
+
+PR 5 で整備した API + Broadcast を Next.js から消費し、出品 / 一覧 / 詳細 / 入札 / リアルタイム価格更新までを画面で完結させる。
+
+## 画面
+
+- `/auctions` — 一覧。各オークションのタイトル / 現在価格 / status / 出品者
+- `/auctions/new` — 出品フォーム (タイトル / 説明 / 開始価格 / 入札単位 / 開始・終了日時)
+- `/auctions/[id]` — 詳細 (出品情報 + 入札フォーム + リアルタイム入札ログ)
+- ホーム (`/`) のナビに「オークション一覧」を追加
+
+## ライブラリ
+
+- API クライアント `frontend/lib/auctions.ts`: `fetchAuctions` / `fetchAuction` / `createAuction` / `placeBid`
+- Echo は既存の `frontend/lib/echo.ts` を流用 (broadcaster: \`reverb\`、channel `auction.{id}`)
+
+## 動作確認 (Chrome)
+
+事前に `php artisan reverb:start` と `npm run dev` を起動。`migrate:fresh` 後に seller / bidder / 1 件のオークション (5000 円 / 入札単位 500 円) を seed。
+
+### 1. 一覧
+
+```
+heading "オークション一覧"
+link "出品する" → /auctions/new
+list
+  listitem
+    link → /auctions/1
+      "ヴィンテージ腕時計"
+      "現在価格" "5,000" 円
+    "出品者: Seller Sato"
+```
+
+### 2. 詳細 (未ログイン or seller としてアクセス)
+
+未ログインなら「入札にはログインが必要です」、seller としてアクセスすると「自分の出品物には入札できません」と表示され、入札フォームは出ない。
+
+### 3. bidder としてログインして入札
+
+`/login` で `bidder@example.com` / `password` でログイン後 `/auctions/1` を再表示すると、入札フォームが現れ、入力欄は \`min_next_bid\` (= 5000) で初期化される。
+
+「入札する」を押下 → `POST /api/auctions/1/bids` が発火 → `BidPlaced` event が `auction.1` チャネルに broadcast され、自分自身も受信:
+
+```
+generic "現在価格" "5,000 円"      # 初回入札 (額が starting_price と同じ) のため見た目は変化しない
+generic "最低次回入札" "5,500 円"  # 5000 + 500
+generic "最高入札者" "Bidder Brown"
+listitem "Bidder Brown が 5,000 円で入札"
+```
+
+続けて 6000 円で入札:
+
+```
+generic "現在価格" "6,000 円"      # ← 5000 → 6000 にリアルタイム更新
+generic "最低次回入札" "6,500 円"
+generic "最高入札者" "Bidder Brown"
+list (新しい順)
+  listitem "Bidder Brown が 6,000 円で入札"
+  listitem "Bidder Brown が 5,000 円で入札"
+```
+
+入札額の input は `min_next_bid` (= 6500) で自動再初期化される。
+
+### 4. クロスガード分離 / アクセス制御
+
+- 未ログインで `/auctions/new` を踏むと `/login` にリダイレクト
+- 未ログインの詳細表示でも閲覧は可能 (channel が公開のため observation だけはできる)
+- seller としてログインすると自分の出品には入札できない (UI レベルでフォーム非表示、API レベルでもガード済み — PR 5 のテスト参照)
+
+## 自動チェック
+
+- `npm run lint` (Next.js 16 / ESLint 9) PASS
+- `npm run build` PASS
+  - 新ルート: `/auctions`, `/auctions/[id]` (ƒ Dynamic), `/auctions/new`
+- `make build` (Laravel 側、ファイル追加なし) PASS
+- `make test` (29 件、PR 5 由来含む) PASS
+
+## 既知の挙動
+
+- `BidPlaced` の broadcast は `QUEUE_CONNECTION=sync` のため Reverb への HTTP publish が同期実行される。**Reverb サーバが落ちていると入札 API が 500 を返す** が、bid 自体は DB に保存される (cf. PR 5 README)
+- 開発時は Reverb と Next.js dev の両方を起動する必要がある:
+  ```
+  ./vendor/bin/sail artisan reverb:start --host=0.0.0.0 --port=8080
+  ./vendor/bin/sail bash -c "cd frontend && npm run dev"
+  ```
+
+## 完成したスタック
+
+| レイヤ | 技術 |
+|---|---|
+| バックエンド | Laravel 13 + PHP 8.4 + Sanctum 4 |
+| フロント | Next.js 16 + React 19 + TypeScript + Tailwind 4 |
+| 認証 | Sanctum SPA 認証 (Multi-guard: web / admin) |
+| WebSocket | Laravel Reverb 1.10 (Pusher 互換) |
+| クライアント受信 | laravel-echo + pusher-js |
+| 開発環境 | Laravel Sail (Docker) |

--- a/frontend/app/auctions/[id]/page.tsx
+++ b/frontend/app/auctions/[id]/page.tsx
@@ -1,0 +1,196 @@
+'use client';
+
+import { use, useEffect, useState } from 'react';
+import { Auction, BidPlacedPayload, fetchAuction, placeBid } from '@/lib/auctions';
+import { useUser } from '@/lib/auth';
+import { getEcho } from '@/lib/echo';
+
+type Props = { params: Promise<{ id: string }> };
+
+export default function AuctionDetailPage({ params }: Props) {
+  const { id } = use(params);
+  const auctionId = Number(id);
+  const { auth } = useUser();
+  const [auction, setAuction] = useState<Auction | null>(null);
+  const [bidAmount, setBidAmount] = useState('');
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+  const [activity, setActivity] = useState<string[]>([]);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchAuction(auctionId).then((a) => {
+      if (!cancelled) {
+        setAuction(a);
+        setBidAmount(String(a.min_next_bid));
+      }
+    });
+    return () => {
+      cancelled = true;
+    };
+  }, [auctionId]);
+
+  useEffect(() => {
+    const echo = getEcho();
+    const channel = echo.channel(`auction.${auctionId}`);
+
+    channel.listen('.bid.placed', (payload: BidPlacedPayload) => {
+      setAuction((prev) =>
+        prev
+          ? {
+              ...prev,
+              current_price: payload.auction.current_price,
+              min_next_bid: payload.auction.min_next_bid,
+              current_winner: payload.auction.current_winner,
+            }
+          : prev,
+      );
+      setBidAmount(String(payload.auction.min_next_bid));
+      setActivity((prev) => [
+        `${payload.bid.bidder.name} が ${payload.bid.amount.toLocaleString()} 円で入札`,
+        ...prev,
+      ]);
+    });
+
+    return () => {
+      echo.leave(`auction.${auctionId}`);
+    };
+  }, [auctionId]);
+
+  const handleBid = async () => {
+    setError(null);
+    setSubmitting(true);
+    try {
+      await placeBid(auctionId, Number(bidAmount));
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'response' in err
+          ? extractMessage(err)
+          : err instanceof Error
+            ? err.message
+            : 'bid failed';
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  if (!auction) {
+    return <main className="p-8 text-sm">読み込み中...</main>;
+  }
+
+  const isAuthenticated = auth.state === 'authenticated';
+  const isOwner = isAuthenticated && auth.principal.id === auction.seller.id;
+  const canBid = isAuthenticated && !isOwner && auction.status === 'active';
+
+  return (
+    <main className="mx-auto mt-12 flex w-full max-w-2xl flex-col gap-6 p-6">
+      <header className="flex flex-col gap-2">
+        <h1 className="text-2xl font-semibold">{auction.title}</h1>
+        <p className="text-sm text-zinc-600 dark:text-zinc-400">
+          出品者: {auction.seller.name} / status: <strong>{auction.status}</strong>
+        </p>
+      </header>
+
+      <section className="rounded-lg border border-zinc-300 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+        <p className="whitespace-pre-wrap text-sm">{auction.description}</p>
+      </section>
+
+      <section className="rounded-lg border border-zinc-300 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+        <dl className="grid grid-cols-[auto_1fr] gap-x-4 gap-y-2 text-sm">
+          <dt className="text-zinc-500">開始価格</dt>
+          <dd>{auction.starting_price.toLocaleString()} 円</dd>
+          <dt className="text-zinc-500">現在価格</dt>
+          <dd className="text-lg font-semibold text-emerald-600 dark:text-emerald-400">
+            {auction.current_price.toLocaleString()} 円
+          </dd>
+          <dt className="text-zinc-500">最低次回入札</dt>
+          <dd>{auction.min_next_bid.toLocaleString()} 円</dd>
+          <dt className="text-zinc-500">最高入札者</dt>
+          <dd>{auction.current_winner ? auction.current_winner.name : '—'}</dd>
+          <dt className="text-zinc-500">開始</dt>
+          <dd>{new Date(auction.starts_at).toLocaleString('ja-JP')}</dd>
+          <dt className="text-zinc-500">終了</dt>
+          <dd>{new Date(auction.ends_at).toLocaleString('ja-JP')}</dd>
+        </dl>
+      </section>
+
+      <section className="rounded-lg border border-zinc-300 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+        <h2 className="mb-3 text-base font-semibold">入札</h2>
+        {!isAuthenticated && (
+          <p className="text-sm text-zinc-600 dark:text-zinc-400">
+            入札にはログインが必要です
+          </p>
+        )}
+        {isOwner && (
+          <p className="text-sm text-zinc-600 dark:text-zinc-400">
+            自分の出品物には入札できません
+          </p>
+        )}
+        {auction.status !== 'active' && (
+          <p className="text-sm text-zinc-600 dark:text-zinc-400">
+            現在は受付中ではありません
+          </p>
+        )}
+        {canBid && (
+          <div className="flex flex-col gap-2">
+            <label className="flex flex-col gap-1 text-sm">
+              入札額 (円)
+              <input
+                type="number"
+                value={bidAmount}
+                min={auction.min_next_bid}
+                onChange={(e) => setBidAmount(e.target.value)}
+                className="rounded border border-zinc-300 bg-white px-3 py-2 text-base dark:border-zinc-700 dark:bg-zinc-950"
+              />
+            </label>
+            <button
+              type="button"
+              onClick={handleBid}
+              disabled={submitting}
+              className="self-start rounded bg-zinc-900 px-4 py-2 text-base font-medium text-white disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900"
+            >
+              {submitting ? '送信中…' : '入札する'}
+            </button>
+            {error && (
+              <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+                {error}
+              </p>
+            )}
+          </div>
+        )}
+      </section>
+
+      <section className="rounded-lg border border-zinc-300 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900">
+        <h2 className="mb-3 text-base font-semibold">入札ログ (リアルタイム)</h2>
+        {activity.length === 0 ? (
+          <p className="text-sm text-zinc-500">まだ入札はありません</p>
+        ) : (
+          <ol className="flex flex-col gap-1 text-sm">
+            {activity.map((entry, index) => (
+              <li key={`${entry}-${index}`} className="font-mono text-xs">
+                {entry}
+              </li>
+            ))}
+          </ol>
+        )}
+      </section>
+    </main>
+  );
+}
+
+const extractMessage = (err: { response?: unknown }): string => {
+  const response = err.response;
+  if (
+    response &&
+    typeof response === 'object' &&
+    'data' in response &&
+    response.data &&
+    typeof response.data === 'object' &&
+    'message' in response.data &&
+    typeof response.data.message === 'string'
+  ) {
+    return response.data.message;
+  }
+  return 'bid failed';
+};

--- a/frontend/app/auctions/new/page.tsx
+++ b/frontend/app/auctions/new/page.tsx
@@ -1,0 +1,169 @@
+'use client';
+
+import { useRouter } from 'next/navigation';
+import { FormEvent, useState } from 'react';
+import { createAuction } from '@/lib/auctions';
+import { useUser } from '@/lib/auth';
+
+const toLocalIso = (offsetMinutes: number): string => {
+  const d = new Date(Date.now() + offsetMinutes * 60 * 1000);
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return `${d.getFullYear()}-${pad(d.getMonth() + 1)}-${pad(d.getDate())}T${pad(d.getHours())}:${pad(d.getMinutes())}`;
+};
+
+export default function NewAuctionPage() {
+  const router = useRouter();
+  const { auth } = useUser();
+  const [title, setTitle] = useState('');
+  const [description, setDescription] = useState('');
+  const [startingPrice, setStartingPrice] = useState(1000);
+  const [bidIncrement, setBidIncrement] = useState(100);
+  const [startsAt, setStartsAt] = useState(() => toLocalIso(-1));
+  const [endsAt, setEndsAt] = useState(() => toLocalIso(60));
+  const [error, setError] = useState<string | null>(null);
+  const [submitting, setSubmitting] = useState(false);
+
+  if (auth.state === 'unauthenticated') {
+    router.replace('/login');
+    return null;
+  }
+  if (auth.state === 'loading') {
+    return <main className="p-8 text-sm">読み込み中...</main>;
+  }
+
+  const handleSubmit = async (event: FormEvent<HTMLFormElement>) => {
+    event.preventDefault();
+    setSubmitting(true);
+    setError(null);
+    try {
+      const created = await createAuction({
+        title,
+        description,
+        starting_price: startingPrice,
+        bid_increment: bidIncrement,
+        starts_at: new Date(startsAt).toISOString(),
+        ends_at: new Date(endsAt).toISOString(),
+      });
+      router.push(`/auctions/${created.id}`);
+    } catch (err: unknown) {
+      const message =
+        err && typeof err === 'object' && 'response' in err
+          ? extractMessage(err)
+          : err instanceof Error
+            ? err.message
+            : 'failed';
+      setError(message);
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <main className="mx-auto mt-12 flex w-full max-w-2xl flex-col gap-4 p-6">
+      <h1 className="text-2xl font-semibold">出品する</h1>
+
+      <form onSubmit={handleSubmit} className="flex flex-col gap-4">
+        <Field label="タイトル">
+          <input
+            type="text"
+            value={title}
+            onChange={(e) => setTitle(e.target.value)}
+            required
+            maxLength={120}
+            className={inputClasses}
+          />
+        </Field>
+
+        <Field label="説明">
+          <textarea
+            value={description}
+            onChange={(e) => setDescription(e.target.value)}
+            required
+            rows={3}
+            className={inputClasses}
+          />
+        </Field>
+
+        <div className="grid grid-cols-2 gap-4">
+          <Field label="開始価格 (円)">
+            <input
+              type="number"
+              min={1}
+              value={startingPrice}
+              onChange={(e) => setStartingPrice(Number(e.target.value))}
+              className={inputClasses}
+            />
+          </Field>
+          <Field label="入札単位 (円)">
+            <input
+              type="number"
+              min={1}
+              value={bidIncrement}
+              onChange={(e) => setBidIncrement(Number(e.target.value))}
+              className={inputClasses}
+            />
+          </Field>
+        </div>
+
+        <div className="grid grid-cols-2 gap-4">
+          <Field label="開始日時">
+            <input
+              type="datetime-local"
+              value={startsAt}
+              onChange={(e) => setStartsAt(e.target.value)}
+              className={inputClasses}
+            />
+          </Field>
+          <Field label="終了日時">
+            <input
+              type="datetime-local"
+              value={endsAt}
+              onChange={(e) => setEndsAt(e.target.value)}
+              className={inputClasses}
+            />
+          </Field>
+        </div>
+
+        {error && (
+          <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+            {error}
+          </p>
+        )}
+
+        <button
+          type="submit"
+          disabled={submitting}
+          className="self-start rounded bg-zinc-900 px-4 py-2 text-base font-medium text-white disabled:opacity-50 dark:bg-zinc-100 dark:text-zinc-900"
+        >
+          {submitting ? '送信中…' : '出品する'}
+        </button>
+      </form>
+    </main>
+  );
+}
+
+const inputClasses =
+  'w-full rounded border border-zinc-300 bg-white px-3 py-2 text-base dark:border-zinc-700 dark:bg-zinc-950';
+
+const Field = ({ label, children }: { label: string; children: React.ReactNode }) => (
+  <label className="flex flex-col gap-1 text-sm">
+    {label}
+    {children}
+  </label>
+);
+
+const extractMessage = (err: { response?: unknown }): string => {
+  const response = err.response;
+  if (
+    response &&
+    typeof response === 'object' &&
+    'data' in response &&
+    response.data &&
+    typeof response.data === 'object' &&
+    'message' in response.data &&
+    typeof response.data.message === 'string'
+  ) {
+    return response.data.message;
+  }
+  return 'failed to create auction';
+};

--- a/frontend/app/auctions/page.tsx
+++ b/frontend/app/auctions/page.tsx
@@ -1,0 +1,77 @@
+'use client';
+
+import Link from 'next/link';
+import { useEffect, useState } from 'react';
+import { Auction, fetchAuctions } from '@/lib/auctions';
+
+export default function AuctionsListPage() {
+  const [auctions, setAuctions] = useState<Auction[] | null>(null);
+  const [error, setError] = useState<string | null>(null);
+
+  useEffect(() => {
+    let cancelled = false;
+    fetchAuctions()
+      .then((data) => {
+        if (!cancelled) setAuctions(data);
+      })
+      .catch((err: unknown) => {
+        if (!cancelled) {
+          setError(err instanceof Error ? err.message : 'failed to fetch');
+        }
+      });
+    return () => {
+      cancelled = true;
+    };
+  }, []);
+
+  return (
+    <main className="mx-auto mt-12 flex w-full max-w-3xl flex-col gap-4 p-6">
+      <header className="flex items-center justify-between">
+        <h1 className="text-2xl font-semibold">オークション一覧</h1>
+        <Link
+          href="/auctions/new"
+          className="rounded bg-zinc-900 px-3 py-2 text-sm font-medium text-white dark:bg-zinc-100 dark:text-zinc-900"
+        >
+          出品する
+        </Link>
+      </header>
+
+      {error && (
+        <p role="alert" className="text-sm text-red-600 dark:text-red-400">
+          {error}
+        </p>
+      )}
+
+      {auctions === null && !error && (
+        <p className="text-sm text-zinc-600 dark:text-zinc-400">読み込み中...</p>
+      )}
+
+      {auctions !== null && auctions.length === 0 && (
+        <p className="text-sm text-zinc-600 dark:text-zinc-400">
+          まだオークションはありません
+        </p>
+      )}
+
+      <ul className="flex flex-col gap-3">
+        {auctions?.map((a) => (
+          <li
+            key={a.id}
+            className="rounded-lg border border-zinc-300 bg-white p-4 dark:border-zinc-700 dark:bg-zinc-900"
+          >
+            <Link
+              href={`/auctions/${a.id}`}
+              className="flex items-baseline justify-between gap-4"
+            >
+              <span className="font-medium">{a.title}</span>
+              <span className="text-sm text-zinc-500">
+                {a.status === 'active' ? '現在価格' : a.status === 'ended' ? '終了' : '開始前'}{' '}
+                <strong>{a.current_price.toLocaleString()}</strong> 円
+              </span>
+            </Link>
+            <p className="mt-1 truncate text-xs text-zinc-500">出品者: {a.seller.name}</p>
+          </li>
+        ))}
+      </ul>
+    </main>
+  );
+}

--- a/frontend/app/page.tsx
+++ b/frontend/app/page.tsx
@@ -49,6 +49,12 @@ export default function Home() {
 
       <nav className="flex flex-wrap justify-center gap-4 text-sm">
         <Link
+          href="/auctions"
+          className="rounded bg-zinc-900 px-4 py-2 text-white dark:bg-zinc-100 dark:text-zinc-900"
+        >
+          オークション一覧
+        </Link>
+        <Link
           href="/login"
           className="rounded border border-zinc-300 px-4 py-2 dark:border-zinc-700"
         >

--- a/frontend/lib/auctions.ts
+++ b/frontend/lib/auctions.ts
@@ -1,0 +1,72 @@
+import { api, ensureCsrfCookie } from './api';
+
+export type AuctionStatus = 'pending' | 'active' | 'ended';
+
+export type AuctionUser = {
+  id: number;
+  name: string;
+};
+
+export type Auction = {
+  id: number;
+  title: string;
+  description: string;
+  seller: AuctionUser;
+  starting_price: number;
+  bid_increment: number;
+  current_price: number;
+  min_next_bid: number;
+  current_winner: AuctionUser | null;
+  starts_at: string;
+  ends_at: string;
+  status: AuctionStatus;
+};
+
+export type Bid = {
+  id: number;
+  auction_id: number;
+  amount: number;
+  bidder: AuctionUser;
+  created_at: string;
+};
+
+export type BidPlacedPayload = {
+  bid: Bid;
+  auction: {
+    id: number;
+    current_price: number;
+    min_next_bid: number;
+    current_winner: AuctionUser;
+  };
+};
+
+export const fetchAuctions = async (): Promise<Auction[]> => {
+  const response = await api.get<{ data: Auction[] }>('/api/auctions');
+  return response.data.data;
+};
+
+export const fetchAuction = async (id: number): Promise<Auction> => {
+  const response = await api.get<{ data: Auction }>(`/api/auctions/${id}`);
+  return response.data.data;
+};
+
+export type CreateAuctionInput = {
+  title: string;
+  description: string;
+  starting_price: number;
+  bid_increment: number;
+  starts_at: string;
+  ends_at: string;
+};
+
+export const createAuction = async (input: CreateAuctionInput): Promise<Auction> => {
+  await ensureCsrfCookie();
+  const response = await api.post<{ data: Auction }>('/api/auctions', input);
+  return response.data.data;
+};
+
+export const placeBid = async (auctionId: number, amount: number): Promise<Bid> => {
+  await ensureCsrfCookie();
+  const response = await api.post<{ data: Bid }>(`/api/auctions/${auctionId}/bids`, { amount });
+  return response.data.data;
+};

--- a/routes/api.php
+++ b/routes/api.php
@@ -1,13 +1,22 @@
 <?php declare(strict_types=1);
 
 use App\Http\Controllers\Api\Admin\AuthController as AdminAuthController;
+use App\Http\Controllers\Api\AuctionController;
 use App\Http\Controllers\Api\AuthController;
+use App\Http\Controllers\Api\BidController;
 use App\Http\Controllers\Api\BroadcastTestController;
 use Illuminate\Support\Facades\Route;
 
 Route::get('/health', static fn () => response()->json(['status' => 'ok']))->name('api.health');
 
 Route::post('/broadcast-test', BroadcastTestController::class)->name('api.broadcast-test');
+
+Route::get('/auctions', [AuctionController::class, 'index'])->name('api.auctions.index');
+Route::get('/auctions/{auction}', [AuctionController::class, 'show'])->name('api.auctions.show');
+Route::middleware('auth:web')->group(static function (): void {
+    Route::post('/auctions', [AuctionController::class, 'store'])->name('api.auctions.store');
+    Route::post('/auctions/{auction}/bids', [BidController::class, 'store'])->name('api.auctions.bids.store');
+});
 
 Route::post('/login', [AuthController::class, 'login'])->name('api.login');
 Route::middleware('auth:web')->group(static function (): void {

--- a/routes/channels.php
+++ b/routes/channels.php
@@ -6,3 +6,6 @@ use Illuminate\Support\Facades\Broadcast;
 Broadcast::channel('public.ping', static fn () => true);
 
 Broadcast::channel('user.{userId}', static fn (User $user, int $userId): bool => $user->id === $userId);
+
+// オークションは観戦自体は誰でも可能 (パブリックチャネル)。入札は API 側で auth + 認可。
+Broadcast::channel('auction.{auctionId}', static fn () => true);

--- a/tests/Feature/Api/AuctionTest.php
+++ b/tests/Feature/Api/AuctionTest.php
@@ -1,0 +1,103 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Http\Middleware\VerifyCsrfToken;
+use App\Models\Auction;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class AuctionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware(VerifyCsrfToken::class);
+        $this->withHeader('Origin', 'http://localhost:3000');
+    }
+
+    public function testIndexReturnsAllAuctions(): void
+    {
+        Auction::factory()->count(3)->create();
+
+        $response = $this->getJson('/api/auctions');
+
+        $response->assertOk()
+            ->assertJsonCount(3, 'data');
+    }
+
+    public function testShowReturnsSingleAuction(): void
+    {
+        $auction = Auction::factory()->create();
+
+        $response = $this->getJson("/api/auctions/{$auction->id}");
+
+        $response->assertOk()
+            ->assertJson([
+                'data' => [
+                    'id' => $auction->id,
+                    'title' => $auction->title,
+                    'status' => 'active',
+                ],
+            ]);
+    }
+
+    public function testStoreCreatesAuctionForAuthenticatedUser(): void
+    {
+        $user = User::factory()->create();
+
+        $payload = [
+            'title' => 'Test auction',
+            'description' => 'Test description',
+            'starting_price' => 1000,
+            'bid_increment' => 100,
+            'starts_at' => now()->subMinute()->toIso8601String(),
+            'ends_at' => now()->addHour()->toIso8601String(),
+        ];
+
+        $response = $this->actingAs($user)->postJson('/api/auctions', $payload);
+
+        $response->assertCreated()
+            ->assertJson([
+                'data' => [
+                    'title' => 'Test auction',
+                    'starting_price' => 1000,
+                    'current_price' => 1000,
+                    'min_next_bid' => 1000,
+                    'seller' => ['id' => $user->id],
+                ],
+            ]);
+
+        $this->assertDatabaseHas('auctions', [
+            'seller_user_id' => $user->id,
+            'title' => 'Test auction',
+        ]);
+    }
+
+    public function testStoreRequiresAuthentication(): void
+    {
+        $response = $this->postJson('/api/auctions', []);
+
+        $response->assertStatus(401);
+    }
+
+    public function testStoreValidatesEndAfterStart(): void
+    {
+        $user = User::factory()->create();
+
+        $response = $this->actingAs($user)->postJson('/api/auctions', [
+            'title' => 'x',
+            'description' => 'x',
+            'starting_price' => 100,
+            'bid_increment' => 10,
+            'starts_at' => now()->addHour()->toIso8601String(),
+            'ends_at' => now()->subHour()->toIso8601String(),
+        ]);
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['ends_at']);
+    }
+}

--- a/tests/Feature/Api/BidTest.php
+++ b/tests/Feature/Api/BidTest.php
@@ -1,0 +1,139 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Events\BidPlaced;
+use App\Http\Middleware\VerifyCsrfToken;
+use App\Models\Auction;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class BidTest extends TestCase
+{
+    use RefreshDatabase;
+
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware(VerifyCsrfToken::class);
+        $this->withHeader('Origin', 'http://localhost:3000');
+    }
+
+    public function testPlaceBidSucceedsAndBroadcasts(): void
+    {
+        Event::fake();
+
+        $auction = Auction::factory()->create([
+            'starting_price' => 1000,
+            'bid_increment' => 100,
+            'current_price' => 1000,
+        ]);
+        $bidder = User::factory()->create();
+
+        $response = $this->actingAs($bidder)->postJson(
+            "/api/auctions/{$auction->id}/bids",
+            ['amount' => 1000],
+        );
+
+        $response->assertCreated()
+            ->assertJson([
+                'data' => [
+                    'auction_id' => $auction->id,
+                    'amount' => 1000,
+                    'bidder' => ['id' => $bidder->id],
+                ],
+            ]);
+
+        $this->assertDatabaseHas('bids', [
+            'auction_id' => $auction->id,
+            'user_id' => $bidder->id,
+            'amount' => 1000,
+        ]);
+
+        $auction->refresh();
+        $this->assertSame(1000, $auction->current_price);
+        $this->assertSame($bidder->id, $auction->current_winner_user_id);
+
+        Event::assertDispatched(BidPlaced::class);
+    }
+
+    public function testNextBidMustBeAtLeastIncrementAboveCurrentPrice(): void
+    {
+        $previousBidder = User::factory()->create();
+        $auction = Auction::factory()->create([
+            'starting_price' => 1000,
+            'bid_increment' => 100,
+            'current_price' => 1500,
+            'current_winner_user_id' => $previousBidder->id,
+        ]);
+        $bidder = User::factory()->create();
+
+        $response = $this->actingAs($bidder)->postJson(
+            "/api/auctions/{$auction->id}/bids",
+            ['amount' => 1500],
+        );
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['amount']);
+    }
+
+    public function testCannotBidOnOwnAuction(): void
+    {
+        $seller = User::factory()->create();
+        $auction = Auction::factory()->create([
+            'seller_user_id' => $seller->id,
+            'starting_price' => 1000,
+            'current_price' => 1000,
+        ]);
+
+        $response = $this->actingAs($seller)->postJson(
+            "/api/auctions/{$auction->id}/bids",
+            ['amount' => 2000],
+        );
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['amount']);
+    }
+
+    public function testCannotBidOnEndedAuction(): void
+    {
+        $auction = Auction::factory()->ended()->create();
+        $bidder = User::factory()->create();
+
+        $response = $this->actingAs($bidder)->postJson(
+            "/api/auctions/{$auction->id}/bids",
+            ['amount' => 99999],
+        );
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['amount']);
+    }
+
+    public function testCannotBidOnPendingAuction(): void
+    {
+        $auction = Auction::factory()->pending()->create();
+        $bidder = User::factory()->create();
+
+        $response = $this->actingAs($bidder)->postJson(
+            "/api/auctions/{$auction->id}/bids",
+            ['amount' => 99999],
+        );
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['amount']);
+    }
+
+    public function testBidRequiresAuthentication(): void
+    {
+        $auction = Auction::factory()->create();
+
+        $response = $this->postJson(
+            "/api/auctions/{$auction->id}/bids",
+            ['amount' => 99999],
+        );
+
+        $response->assertStatus(401);
+    }
+}


### PR DESCRIPTION
## 背景

PR #78 で整備した オークション API + Broadcast を Next.js から消費して、出品 / 一覧 / 詳細 / 入札を画面で完結させる。入札があると Laravel が `BidPlaced` を `auction.{id}` チャネルに broadcast し、Next.js 側は Echo でそれを受けて画面の **現在価格 / 最低次回入札 / 最高入札者 / 入札ログ をリアルタイムで更新** する。

## 変更内容

### ライブラリ
- \`frontend/lib/auctions.ts\`: API ラッパ + 型 (\`Auction\`, \`Bid\`, \`BidPlacedPayload\`)
  - \`fetchAuctions\` / \`fetchAuction\` / \`createAuction\` / \`placeBid\`
  - \`createAuction\` / \`placeBid\` は \`ensureCsrfCookie()\` を経由

### 画面
- \`/auctions\` — 一覧 (タイトル / 現在価格 / status / 出品者)
- \`/auctions/new\` — 出品フォーム (タイトル / 説明 / 開始価格 / 入札単位 / 開始日時 / 終了日時)
  - 未ログインは \`useUser\` で検出して \`/login\` にリダイレクト
- \`/auctions/[id]\` — 詳細
  - 出品情報 (説明 / 開始価格 / 現在価格 / 最低次回入札 / 最高入札者 / 開始・終了日時 / status)
  - 入札フォーム (auth 必須 / seller 不可 / status === 'active' のみ表示)
  - 入札ログ (リアルタイム)
  - useEffect で Echo の \`auction.{id}\` チャネル \`.bid.placed\` を購読 → \`setAuction\` で価格更新 + 入札ログに append
- ホーム (\`/\`) のナビに「オークション一覧」を追加

## 動作確認

\`docs/evidence/auction-ui/README.md\` に詳細。要約:

- 一覧から詳細に遷移、未ログインで「入札にはログインが必要です」が表示される
- bidder としてログイン後、入札フォームが現れ、入力欄が \`min_next_bid\` で初期化される
- 「入札する」を押すと、\`POST /api/auctions/{id}/bids\` が走り、自身も \`BidPlaced\` を受信して画面が更新される
- 続けて 6000 円入札 → 現在価格が 5,000 → 6,000 にリアルタイム更新、最低次回入札 6,500 円、入札ログに 2 件記録

\`npm run lint\` / \`npm run build\` (Next.js 16) PASS。\`make build\` / \`make test\` (29 件) PASS。

## 既知の挙動

- broadcast は \`QUEUE_CONNECTION=sync\` のため Reverb への HTTP publish が同期実行される。**Reverb サーバが落ちていると入札 API が 500 を返す** が、bid 自体は DB に保存される
- 開発時は Reverb と Next.js dev の両方を起動する必要がある:
  - \`./vendor/bin/sail artisan reverb:start --host=0.0.0.0 --port=8080\`
  - \`./vendor/bin/sail bash -c \"cd frontend && npm run dev\"\`

## これで完成したスタック

| レイヤ | 技術 |
|---|---|
| バックエンド | Laravel 13 + PHP 8.4 + Sanctum 4 |
| フロント | Next.js 16 + React 19 + TypeScript + Tailwind 4 |
| 認証 | Sanctum SPA 認証 (Multi-guard: web / admin) |
| WebSocket | Laravel Reverb 1.10 (Pusher 互換) |
| クライアント受信 | laravel-echo + pusher-js |
| 開発環境 | Laravel Sail (Docker) |

PR 1〜6 で計画したフェーズはすべて完了。

🤖 Generated with [Claude Code](https://claude.com/claude-code)