### PR TITLE
test: Auction/Bid/Event/Broadcast チャネル等の不足テストを追加

### DIFF
--- a/tests/Feature/Api/AuctionTest.php
+++ b/tests/Feature/Api/AuctionTest.php
@@ -29,6 +29,18 @@ class AuctionTest extends TestCase
             ->assertJsonCount(3, 'data');
     }
 
+    public function testIndexOrdersByIdDescending(): void
+    {
+        $first = Auction::factory()->create();
+        $second = Auction::factory()->create();
+        $third = Auction::factory()->create();
+
+        $response = $this->getJson('/api/auctions');
+
+        $ids = array_column($response->json('data'), 'id');
+        $this->assertSame([$third->id, $second->id, $first->id], $ids);
+    }
+
     public function testShowReturnsSingleAuction(): void
     {
         $auction = Auction::factory()->create();
@@ -43,6 +55,41 @@ class AuctionTest extends TestCase
                     'status' => 'active',
                 ],
             ]);
+    }
+
+    public function testShowReturnsPendingStatusBeforeStart(): void
+    {
+        $auction = Auction::factory()->pending()->create();
+
+        $response = $this->getJson("/api/auctions/{$auction->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.status', 'pending');
+    }
+
+    public function testShowReturnsEndedStatusAfterEnd(): void
+    {
+        $auction = Auction::factory()->ended()->create();
+
+        $response = $this->getJson("/api/auctions/{$auction->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.status', 'ended');
+    }
+
+    public function testShowIncludesCurrentWinnerWhenPresent(): void
+    {
+        $winner = User::factory()->create(['name' => 'Winner Jane']);
+        $auction = Auction::factory()->create([
+            'current_winner_user_id' => $winner->id,
+            'current_price' => 5000,
+        ]);
+
+        $response = $this->getJson("/api/auctions/{$auction->id}");
+
+        $response->assertOk()
+            ->assertJsonPath('data.current_winner.id', $winner->id)
+            ->assertJsonPath('data.current_winner.name', 'Winner Jane');
     }
 
     public function testStoreCreatesAuctionForAuthenticatedUser(): void

--- a/tests/Feature/Api/BidTest.php
+++ b/tests/Feature/Api/BidTest.php
@@ -136,4 +136,51 @@ class BidTest extends TestCase
 
         $response->assertStatus(401);
     }
+
+    public function testBidValidatesAmountRequired(): void
+    {
+        $auction = Auction::factory()->create();
+        $bidder = User::factory()->create();
+
+        $response = $this->actingAs($bidder)->postJson(
+            "/api/auctions/{$auction->id}/bids",
+            [],
+        );
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['amount']);
+    }
+
+    public function testBidValidatesAmountIsPositiveInteger(): void
+    {
+        $auction = Auction::factory()->create();
+        $bidder = User::factory()->create();
+
+        $response = $this->actingAs($bidder)->postJson(
+            "/api/auctions/{$auction->id}/bids",
+            ['amount' => 0],
+        );
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['amount']);
+    }
+
+    public function testFirstBidMustMeetStartingPrice(): void
+    {
+        $auction = Auction::factory()->create([
+            'starting_price' => 1000,
+            'bid_increment' => 100,
+            'current_price' => 1000,
+            'current_winner_user_id' => null,
+        ]);
+        $bidder = User::factory()->create();
+
+        $response = $this->actingAs($bidder)->postJson(
+            "/api/auctions/{$auction->id}/bids",
+            ['amount' => 999],
+        );
+
+        $response->assertStatus(422)
+            ->assertJsonValidationErrors(['amount']);
+    }
 }

--- a/tests/Feature/Api/BroadcastTestControllerTest.php
+++ b/tests/Feature/Api/BroadcastTestControllerTest.php
@@ -1,0 +1,40 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use App\Events\PingBroadcasted;
+use App\Http\Middleware\VerifyCsrfToken;
+use Illuminate\Support\Facades\Event;
+use Tests\TestCase;
+
+class BroadcastTestControllerTest extends TestCase
+{
+    protected function setUp(): void
+    {
+        parent::setUp();
+        $this->withoutMiddleware(VerifyCsrfToken::class);
+        $this->withHeader('Origin', 'http://localhost:3000');
+    }
+
+    public function testBroadcastTestDispatchesPingAndReturnsPayload(): void
+    {
+        Event::fake();
+
+        $response = $this->postJson('/api/broadcast-test');
+
+        $response->assertOk()
+            ->assertJson([
+                'broadcast' => 'public.ping',
+                'event' => 'ping',
+                'payload' => [
+                    'message' => 'pong from Laravel',
+                ],
+            ]);
+
+        $response->assertJsonStructure([
+            'payload' => ['message', 'emitted_at'],
+        ]);
+
+        Event::assertDispatched(PingBroadcasted::class);
+    }
+}

--- a/tests/Feature/Api/HealthTest.php
+++ b/tests/Feature/Api/HealthTest.php
@@ -1,0 +1,16 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Feature\Api;
+
+use Tests\TestCase;
+
+class HealthTest extends TestCase
+{
+    public function testHealthEndpointReturnsOk(): void
+    {
+        $response = $this->getJson('/api/health');
+
+        $response->assertOk()
+            ->assertExactJson(['status' => 'ok']);
+    }
+}

--- a/tests/Feature/Broadcasting/ChannelAuthTest.php
+++ b/tests/Feature/Broadcasting/ChannelAuthTest.php
@@ -1,0 +1,64 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Feature\Broadcasting;
+
+use App\Models\User;
+use Closure;
+use Illuminate\Broadcasting\Broadcasters\Broadcaster;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Facades\Broadcast;
+use ReflectionClass;
+use Tests\TestCase;
+
+class ChannelAuthTest extends TestCase
+{
+    use RefreshDatabase;
+
+    /**
+     * @return array<string, Closure>
+     */
+    private function registeredChannels(): array
+    {
+        /** @var Broadcaster $broadcaster */
+        $broadcaster = Broadcast::driver();
+        $reflection = new ReflectionClass($broadcaster);
+        $property = $reflection->getProperty('channels');
+        $property->setAccessible(true);
+
+        /** @var array<string, Closure> $channels */
+        $channels = $property->getValue($broadcaster);
+
+        return $channels;
+    }
+
+    public function testPublicPingChannelAuthorizesAnyone(): void
+    {
+        $callback = $this->registeredChannels()['public.ping'];
+
+        $this->assertTrue($callback(null));
+    }
+
+    public function testAuctionChannelAuthorizesAnyone(): void
+    {
+        $callback = $this->registeredChannels()['auction.{auctionId}'];
+
+        $this->assertTrue($callback(null, 42));
+    }
+
+    public function testUserChannelAuthorizesMatchingUser(): void
+    {
+        $user = User::factory()->create();
+        $callback = $this->registeredChannels()['user.{userId}'];
+
+        $this->assertTrue($callback($user, $user->id));
+    }
+
+    public function testUserChannelRejectsDifferentUser(): void
+    {
+        $user = User::factory()->create();
+        $other = User::factory()->create();
+        $callback = $this->registeredChannels()['user.{userId}'];
+
+        $this->assertFalse($callback($user, $other->id));
+    }
+}

--- a/tests/Unit/Events/BidPlacedTest.php
+++ b/tests/Unit/Events/BidPlacedTest.php
@@ -1,0 +1,62 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Events;
+
+use App\Events\BidPlaced;
+use App\Models\Auction;
+use App\Models\Bid;
+use App\Models\User;
+use Illuminate\Broadcasting\Channel;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Tests\TestCase;
+
+class BidPlacedTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testBroadcastOnReturnsAuctionChannelWithId(): void
+    {
+        $auction = Auction::factory()->create();
+        $bid = Bid::factory()->create(['auction_id' => $auction->id]);
+
+        $channels = (new BidPlaced($bid))->broadcastOn();
+
+        $this->assertCount(1, $channels);
+        $this->assertInstanceOf(Channel::class, $channels[0]);
+        $this->assertSame("auction.{$auction->id}", $channels[0]->name);
+    }
+
+    public function testBroadcastAsReturnsBidPlaced(): void
+    {
+        $bid = Bid::factory()->create();
+
+        $this->assertSame('bid.placed', (new BidPlaced($bid))->broadcastAs());
+    }
+
+    public function testBroadcastWithReturnsExpectedPayload(): void
+    {
+        $bidder = User::factory()->create(['name' => 'Alice']);
+        $auction = Auction::factory()->create([
+            'starting_price' => 1000,
+            'bid_increment' => 100,
+            'current_price' => 1200,
+            'current_winner_user_id' => $bidder->id,
+        ]);
+        $bid = Bid::factory()->create([
+            'auction_id' => $auction->id,
+            'user_id' => $bidder->id,
+            'amount' => 1200,
+        ]);
+
+        $payload = (new BidPlaced($bid))->broadcastWith();
+
+        $this->assertSame($bid->id, $payload['bid']['id']);
+        $this->assertSame(1200, $payload['bid']['amount']);
+        $this->assertSame($bidder->id, $payload['bid']['bidder']['id']);
+        $this->assertSame('Alice', $payload['bid']['bidder']['name']);
+        $this->assertSame($auction->id, $payload['auction']['id']);
+        $this->assertSame(1200, $payload['auction']['current_price']);
+        $this->assertSame(1300, $payload['auction']['min_next_bid']);
+        $this->assertSame($bidder->id, $payload['auction']['current_winner']['id']);
+    }
+}

--- a/tests/Unit/Events/PingBroadcastedTest.php
+++ b/tests/Unit/Events/PingBroadcastedTest.php
@@ -1,0 +1,36 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Events;
+
+use App\Events\PingBroadcasted;
+use Illuminate\Broadcasting\Channel;
+use Tests\TestCase;
+
+class PingBroadcastedTest extends TestCase
+{
+    public function testBroadcastOnReturnsPublicPingChannel(): void
+    {
+        $channels = (new PingBroadcasted('hello', '2026-01-01T00:00:00+00:00'))->broadcastOn();
+
+        $this->assertCount(1, $channels);
+        $this->assertInstanceOf(Channel::class, $channels[0]);
+        $this->assertSame('public.ping', $channels[0]->name);
+    }
+
+    public function testBroadcastAsReturnsPing(): void
+    {
+        $event = new PingBroadcasted('hello', '2026-01-01T00:00:00+00:00');
+
+        $this->assertSame('ping', $event->broadcastAs());
+    }
+
+    public function testBroadcastWithReturnsMessageAndEmittedAt(): void
+    {
+        $event = new PingBroadcasted('hello', '2026-01-01T00:00:00+00:00');
+
+        $this->assertSame([
+            'message' => 'hello',
+            'emitted_at' => '2026-01-01T00:00:00+00:00',
+        ], $event->broadcastWith());
+    }
+}

--- a/tests/Unit/Models/AuctionTest.php
+++ b/tests/Unit/Models/AuctionTest.php
@@ -1,0 +1,66 @@
+<?php declare(strict_types=1);
+
+namespace Tests\Unit\Models;
+
+use App\Models\Auction;
+use App\Models\User;
+use Illuminate\Foundation\Testing\RefreshDatabase;
+use Illuminate\Support\Carbon;
+use Tests\TestCase;
+
+class AuctionTest extends TestCase
+{
+    use RefreshDatabase;
+
+    public function testStatusReturnsPendingWhenStartIsInFuture(): void
+    {
+        $auction = Auction::factory()->pending()->create();
+
+        $this->assertSame('pending', $auction->status);
+        $this->assertFalse($auction->isActive());
+    }
+
+    public function testStatusReturnsActiveDuringWindow(): void
+    {
+        $auction = Auction::factory()->create([
+            'starts_at' => Carbon::now()->subMinute(),
+            'ends_at' => Carbon::now()->addHour(),
+        ]);
+
+        $this->assertSame('active', $auction->status);
+        $this->assertTrue($auction->isActive());
+    }
+
+    public function testStatusReturnsEndedWhenEndIsInPast(): void
+    {
+        $auction = Auction::factory()->ended()->create();
+
+        $this->assertSame('ended', $auction->status);
+        $this->assertFalse($auction->isActive());
+    }
+
+    public function testMinNextBidIsStartingPriceWhenNoWinner(): void
+    {
+        $auction = Auction::factory()->create([
+            'starting_price' => 1000,
+            'bid_increment' => 100,
+            'current_price' => 1000,
+            'current_winner_user_id' => null,
+        ]);
+
+        $this->assertSame(1000, $auction->minNextBid());
+    }
+
+    public function testMinNextBidAddsIncrementToCurrentPriceWhenWinnerExists(): void
+    {
+        $winner = User::factory()->create();
+        $auction = Auction::factory()->create([
+            'starting_price' => 1000,
+            'bid_increment' => 100,
+            'current_price' => 1500,
+            'current_winner_user_id' => $winner->id,
+        ]);
+
+        $this->assertSame(1600, $auction->minNextBid());
+    }
+}


### PR DESCRIPTION
## Summary

- Laravel 側のテストカバレッジが不足していたため補強（29 → 53 tests / 125 assertions、全パス）
- 新規 6 ファイル + 既存 2 ファイル拡張で、未カバーだったモデル/イベント/エンドポイント/チャネル認可を追加

## 追加テスト

### 新規
- **Unit/Models/AuctionTest** — `status` accessor (pending/active/ended)、`isActive()`、`minNextBid()`（winner 有無で分岐）
- **Unit/Events/BidPlacedTest** — `broadcastOn` / `broadcastAs` / `broadcastWith` のペイロード構造
- **Unit/Events/PingBroadcastedTest** — 同上
- **Feature/Api/HealthTest** — `/api/health`
- **Feature/Api/BroadcastTestControllerTest** — `/api/broadcast-test`（`PingBroadcasted` 発火 + レスポンス形）
- **Feature/Broadcasting/ChannelAuthTest** — `channels.php` の認可 callback
  - `BROADCAST_DRIVER=log` だと `/broadcasting/auth` が no-op で常に 200 を返すため、`Broadcaster` の `$channels` を reflection で取り出し、closure を直接実行して検証

### 拡張
- **Feature/Api/AuctionTest** — `ORDER BY id DESC` 検証、`status=pending|ended` のレスポンス、`current_winner` の同梱
- **Feature/Api/BidTest** — `amount` 必須・正整数バリデーション、初回入札が `starting_price` 未満で 422 となるケース

## Test plan

- [x] `make test` (composer test) グリーン (53 tests / 125 assertions)
- [x] `make build` (csf + cs + sa + md) グリーン
- [x] lefthook pre-commit / pre-push パス

🤖 Generated with [Claude Code](https://claude.com/claude-code)