### PR TITLE
chore: admins.role を MySQL native ENUM 型に変更し DB レベルで値を制限

### DIFF
--- a/database/migrations/2026_05_11_020000_change_role_column_type_on_admins_table.php
+++ b/database/migrations/2026_05_11_020000_change_role_column_type_on_admins_table.php
@@ -1,0 +1,33 @@
+<?php declare(strict_types=1);
+
+use App\Enums\AdminRole;
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+    /**
+     * Run the migrations.
+     */
+    public function up(): void
+    {
+        Schema::table('admins', static function (Blueprint $table): void {
+            $table->enum('role', array_column(AdminRole::cases(), 'value'))
+                ->default(AdminRole::GeneralAdmin->value)
+                ->change();
+        });
+    }
+
+    /**
+     * Reverse the migrations.
+     */
+    public function down(): void
+    {
+        Schema::table('admins', static function (Blueprint $table): void {
+            $table->string('role', 32)
+                ->default(AdminRole::GeneralAdmin->value)
+                ->change();
+        });
+    }
+};


### PR DESCRIPTION
## Summary

- `admins.role` を `VARCHAR(32)` から `enum('system_admin','general_admin')` に変更
- 値リストは `AdminRole::cases()` から導出して enum と DB の二重定義を回避
- アプリ側 (`App\Enums\AdminRole` + Eloquent cast) はそのまま動作

## Why

`VARCHAR(32)` のままだと DB 単体では任意の文字列を受け入れてしまい、seeder や手動 SQL 起因で不正値が混入する余地がある。アプリ経由でしか書き込まないという暗黙の前提に頼らず、DB レベルでも値を 2 つに限定する。

正規化（`roles` テーブル切り出し）は現時点では見送り。case は 2 つ固定で増える兆候なし、権限制御も `isSystemAdmin()` boolean 判定のみで RBAC でない、role を動的に編集する UI/API も無いため、enum と DB の二重管理コストが拡張性のメリットを上回ると判断。将来 RBAC が必要になった時点で改めて検討する。

## Test plan

- [x] `make migrate` でマイグレーション適用成功
- [x] `make test` (53 tests / 125 assertions) すべてパス
- [x] `make build` (csf / cs / sa / md) すべて OK
- [x] `SHOW CREATE TABLE admins` で `role` が `enum('system_admin','general_admin') NOT NULL DEFAULT 'general_admin'` に変更されていることを確認
- [x] 不正値 (`'foobar'`) を直接 INSERT すると `ERROR 1265: Data truncated for column 'role'` で拒否されること
- [x] 正常値 (`'system_admin'`) は INSERT 可能
- [x] `migrate:rollback` で `VARCHAR(32)` に戻り、再 `migrate` で再適用できること

🤖 Generated with [Claude Code](https://claude.com/claude-code)