### PR TITLE
chore: サプライチェーン対策フェーズ 1 (cooldown / 最小権限 / ignore-scripts)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -16,9 +16,15 @@ updates:
         update-types:
           - minor
           - patch
+    # 公開直後の悪意あるバージョンを掴まないよう、レピュテーション猶予を入れる
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
 
   - package-ecosystem: npm
-    directory: "/"
+    directory: "/frontend"
     schedule:
       interval: weekly
       day: monday
@@ -33,6 +39,11 @@ updates:
         update-types:
           - minor
           - patch
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3
 
   - package-ecosystem: github-actions
     directory: "/"
@@ -49,3 +60,8 @@ updates:
         update-types:
           - minor
           - patch
+    cooldown:
+      default-days: 7
+      semver-major-days: 30
+      semver-minor-days: 7
+      semver-patch-days: 3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,6 +6,9 @@ on:
   pull_request:
     branches: [main]
 
+permissions:
+  contents: read
+
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true

--- a/frontend/.npmrc
+++ b/frontend/.npmrc
@@ -1,0 +1,7 @@
+# 依存パッケージの postinstall / preinstall / prepare などライフサイクルスクリプトを
+# デフォルトで無効化する。サプライチェーン攻撃（悪性 prepare スクリプトでのトークン窃取等）
+# への基本防御。
+#
+# 必要なネイティブビルドが出てきた場合は、npm 11+ の `--allow-scripts <pkg>` か
+# 個別パッケージへの allowlist 対応を検討する。
+ignore-scripts=true


### PR DESCRIPTION
## Summary

Mini Shai-Hulud 型のサプライチェーン攻撃を踏まえ、当プロジェクトでも入れておくべき基本防御をまとめて導入するフェーズ 1 です。

- **Dependabot cooldown 導入**: composer / npm / github-actions の各エコシステムで、公開後一定期間（default 7 日 / major 30 日 / minor 7 日 / patch 3 日）が経過するまで Dependabot が PR を作らないように制限。攻撃者が悪意あるバージョンを publish した直後に Dependabot auto-merge で main に取り込まれる経路を塞ぐ。
- **npm 監視対象パスの修正**: \`directory: \"/\"\` だったが、ルートに package.json は存在せず Dependabot は何も検出していなかった。実態に合わせて \`/frontend\` に修正。これにより cooldown が機能する。
- **CI ワークフローの最小権限化**: \`.github/workflows/ci.yml\` のトップに \`permissions: contents: read\` を追加し、デフォルトで付与される広い書き込み権限を撤廃。汚染依存が走った場合の GITHUB_TOKEN 露出リスクを下げる。
- **npm ライフサイクルスクリプトの全面停止**: \`frontend/.npmrc\` に \`ignore-scripts=true\` を設定。記事の Mini Shai-Hulud が用いた \`prepare\` 経由の難読化コード実行をブロックする。

## Why this matters

当プロジェクトの \`.github/workflows/dependabot-auto-merge.yml\` は minor/patch の自動マージを許可しており、cooldown が無いと「公開即マルウェア」型の Worm に対して **CI 通過 → auto-merge → main 汚染** という経路が成立してしまう。今回の cooldown でレピュテーション猶予が入り、コミュニティのテイクダウン（Mini Shai-Hulud では数十分単位）に間に合うようになる。

## Test plan

- [x] frontend で \`npm ci\` が \`ignore-scripts=true\` 下でも成功することを確認（node:22-alpine コンテナで 379 packages 追加成功）
- [x] frontend で \`npm run build\` が成功し、全 11 ページが prerender されることを確認
- [x] dependabot.yml の YAML 構文確認
- [ ] この PR の CI ジョブ（php / frontend）が両方 green
- [ ] マージ後、次回 Dependabot 実行時に cooldown が効いていること（運用観察）

## フェーズ 2 以降の予定（別 PR）

1. GitHub Actions の SHA pinning
2. CodeQL の有効化
3. OSV-Scanner の追加
4. \`npm audit\` を moderate に下げる検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)