### PR TITLE
chore: サプライチェーン対策フェーズ 2 (Action SHA pinning / CodeQL / OSV-Scanner)

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -40,10 +40,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup PHP
-        uses: shivammathur/setup-php@v2
+        uses: shivammathur/setup-php@accd6127cb78bee3e8082180cb391013d204ef9f # 2.37.0
         with:
           php-version: ${{ matrix.php }}
           extensions: mbstring, intl, pdo_mysql, pdo_sqlite, sqlite3, bcmath
@@ -55,7 +55,7 @@ jobs:
         run: echo "dir=$(composer config cache-files-dir)" >> "$GITHUB_OUTPUT"
 
       - name: Cache composer dependencies
-        uses: actions/cache@v5
+        uses: actions/cache@27d5ce7f107fe9357f9df03efb73ab90386fccae # v5.0.5
         with:
           path: ${{ steps.composer-cache.outputs.dir }}
           key: ${{ runner.os }}-php-${{ matrix.php }}-composer-${{ hashFiles('**/composer.lock') }}
@@ -105,14 +105,14 @@ jobs:
             --coverage-clover build/coverage/clover.xml
 
       - name: Upload coverage to Codecov
-        uses: codecov/codecov-action@v6
+        uses: codecov/codecov-action@57e3a136b779b570ffcdbf80b3bdc90e7fab3de2 # v6.0.0
         with:
           files: build/coverage/clover.xml
           flags: php
           token: ${{ secrets.CODECOV_TOKEN }}
 
       - name: Upload coverage artifact
-        uses: actions/upload-artifact@v7
+        uses: actions/upload-artifact@043fb46d1a93c77aae656e7c1c64a875d1fc6a0a # v7.0.1
         with:
           name: coverage-php-${{ matrix.php }}
           path: build/coverage
@@ -127,10 +127,10 @@ jobs:
 
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@48b55a011bda9f5d6aeb4c2d9c7362e8dae4041e # v6.4.0
         with:
           node-version: "22"
           cache: npm

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,49 @@
+name: CodeQL
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    # 週次フルスキャン (依存追加や設定漏れの早期検知)
+    - cron: "23 4 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  analyze:
+    name: Analyze (${{ matrix.language }})
+    runs-on: ubuntu-latest
+    permissions:
+      security-events: write
+      packages: read
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - language: javascript-typescript
+            build-mode: none
+          - language: actions
+            build-mode: none
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+        with:
+          languages: ${{ matrix.language }}
+          build-mode: ${{ matrix.build-mode }}
+          queries: security-extended
+
+      - name: Perform CodeQL Analysis
+        uses: github/codeql-action/analyze@7fd177fa680c9881b53cdab4d346d32574c9f7f4 # v3.35.4
+        with:
+          category: "/language:${{ matrix.language }}"

--- a/.github/workflows/dependabot-auto-merge.yml
+++ b/.github/workflows/dependabot-auto-merge.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Fetch Dependabot metadata
         id: metadata
-        uses: dependabot/fetch-metadata@v3
+        uses: dependabot/fetch-metadata@25dd0e34f4fe68f24cc83900b1fe3fe149efef98 # v3.1.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
 

--- a/.github/workflows/osv-scanner.yml
+++ b/.github/workflows/osv-scanner.yml
@@ -1,0 +1,46 @@
+name: OSV-Scanner
+
+# composer audit (Packagist Advisory DB) / npm audit (GitHub Advisory DB) と
+# データソースをずらして二重化する。OSV は両 DB + OSS-Fuzz / RustSec 等を
+# 横断するため、片方の DB に未登録の advisory を拾える。
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+  schedule:
+    - cron: "17 5 * * 1"
+
+permissions:
+  contents: read
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan-scheduled:
+    if: ${{ github.event_name == 'push' || github.event_name == 'schedule' }}
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+    with:
+      scan-args: |-
+        -r
+        ./
+
+  scan-pr:
+    if: ${{ github.event_name == 'pull_request' }}
+    uses: google/osv-scanner-action/.github/workflows/osv-scanner-reusable-pr.yml@9a498708959aeaef5ef730655706c5a1df1edbc2 # v2.3.8
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+      pull-requests: read
+    with:
+      scan-args: |-
+        -r
+        ./

--- a/.github/workflows/release-drafter.yml
+++ b/.github/workflows/release-drafter.yml
@@ -15,7 +15,7 @@ jobs:
       pull-requests: write
     runs-on: ubuntu-latest
     steps:
-      - uses: release-drafter/release-drafter@v7
+      - uses: release-drafter/release-drafter@c2e2804cc59f45f57076a99af580d0fedb697927 # v7.3.0
         with:
           config-name: release-drafter.yml
         env:


### PR DESCRIPTION
## Summary

フェーズ 1 (#83) に続くサプライチェーン対策。Action 改ざん耐性と脆弱性検知の多重化を行う。

- **GitHub Action を全て SHA pinning に変更**
  タグ pin (\`@v6\` など) は mutable で、タグの差し替え／hijack に対して無防備。全 8 Action を commit SHA + バージョンコメント形式に書き換え。
  - \`actions/checkout\`、\`shivammathur/setup-php\`、\`actions/cache\`、\`codecov/codecov-action\`、\`actions/upload-artifact\`、\`actions/setup-node\`、\`dependabot/fetch-metadata\`、\`release-drafter/release-drafter\`
  - Dependabot は \`# vX.Y.Z\` コメントを認識して継続的に PR を作るため、自動更新は維持される
- **CodeQL ワークフロー追加** (\`.github/workflows/codeql.yml\`)
  - 対象言語: \`javascript-typescript\` (frontend) と \`actions\` (workflow 自体の脆弱性)
  - PHP は CodeQL 非対応のため対象外（既存の PHPStan/PHPMD/composer audit でカバー）
  - クエリは \`security-extended\`
  - PR / push / 週次 cron で実行
- **OSV-Scanner ワークフロー追加** (\`.github/workflows/osv-scanner.yml\`)
  - 公式 reusable workflow を SHA pin で利用
  - \`composer audit\` (Packagist DB) / \`npm audit\` (GitHub Advisory DB) と DB ソースをずらして二重化
  - PR 時は新規脆弱性のみ報告、push/schedule 時はフルスキャン

## Why this matters

- **タグ pinning のリスク**: Action 提供者がリポジトリを乗っ取られた場合や、メンテナが悪性コードを push して既存タグを書き換えた場合、SHA pin 以外は即座に汚染を引き込む。
- **SAST の不在**: 現状、JS/TS と GitHub Actions ワークフロー自体のセキュリティ静的解析がゼロ。CodeQL の \`actions\` 言語は workflow 内のシークレットリーク・コマンドインジェクション等を検知できる。
- **OSV の二重化**: composer audit / npm audit の DB に未登録の advisory を拾える可能性がある。\`high+\` だけを見ている既存の \`npm audit\` の補完にもなる。

## Test plan

- [x] 全ワークフロー YAML が構文的に妥当 (pyyaml で検証)
- [x] 既存 Action の SHA が全て v\\* 最新タグと一致することを GitHub API で確認
- [x] OSV-Scanner reusable workflow の SHA が v2.3.8 と一致
- [x] CodeQL action の SHA が v3.35.4 と一致
- [ ] この PR の CI で従来ジョブ (php / frontend) が引き続き green
- [ ] CodeQL ジョブが完走 (\`javascript-typescript\` / \`actions\` の 2 ジョブ)
- [ ] OSV-Scanner PR ジョブが完走
- [ ] Security タブに Code Scanning / OSV の結果が現れる

## フェーズ 3（別 PR 予定）

- \`composer.json\` の audit 強化設定
- SBOM 生成
- branch protection の actual な監査
- \`npm audit\` を moderate に下げるかどうかの検討

🤖 Generated with [Claude Code](https://claude.com/claude-code)