### PR TITLE
chore: サプライチェーン対策フェーズ 3 (composer audit を abandoned=fail に厳格化)

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -91,7 +91,10 @@
     "config": {
         "optimize-autoloader": true,
         "preferred-install": "dist",
-        "sort-packages": true
+        "sort-packages": true,
+        "audit": {
+            "abandoned": "fail"
+        }
     },
     "minimum-stability": "dev",
     "prefer-stable": true


### PR DESCRIPTION
## Summary

フェーズ 1 (#83) / フェーズ 2 (#84) に続くサプライチェーン対策の仕上げ。今回は composer 側の audit ポリシー強化のみの小さな PR。

- \`composer.json\` の \`config.audit.abandoned\` を \`report\` (デフォルト) から \`fail\` に変更
- これにより既存 CI の \`composer audit --locked\` が abandoned パッケージを検出した時点で落ちる

## Why this matters

abandoned (公式に「放棄」と宣言された) パッケージは:

- 既知脆弱性の修正が永久に来ない
- 攻撃者が引き継いで悪性コードを混入させる典型ベクター（例: 過去の \`event-stream\` / \`coa\` / \`rc\` 系インシデント）

\`composer audit\` のデフォルトは「report のみ（exit 0）」なので、CI で気付いてもマージできてしまう。\`fail\` に上げることで Dependabot 自動マージや手動マージを止める。

## Test plan

- [x] ローカル (composer:2 Docker image) で \`composer audit --locked\` がパスすることを確認 — 現状の依存に abandoned 無し
- [ ] PR の CI で \`composer audit --locked\` ステップが green

## マージ後に別途実施する設定変更（PR 外）

リポジトリの branch protection の required status checks に、フェーズ 2 で追加した新規ジョブを追加する:

- \`Analyze (actions)\` (CodeQL)
- \`Analyze (javascript-typescript)\` (CodeQL)
- \`scan-pr / osv-scan\` (OSV-Scanner)

これは API 経由の設定で、PR diff には現れない。

## 検討して見送ったもの

- **npm audit を moderate に下げる**: 現状で 2 件の transitive postcss advisory（next.js のビルド時依存、実害ほぼゼロ）に当たるため、ノイズ過多と判断。\`ci.yml\` 既存コメントの方針 (\"moderate/low は noise\") とも一致。
- **SBOM 生成**: 個人プロジェクトでは over-engineering。将来必要になったら \`cyclonedx-php-composer\` + \`cyclonedx-node-npm\` で追加。

🤖 Generated with [Claude Code](https://claude.com/claude-code)