### PR TITLE
docs: ブロードキャスト関連クラスに学習用 PHPDoc を追加し User モデルに @property を整備

### DIFF
--- a/app/Events/BidPlaced.php
+++ b/app/Events/BidPlaced.php
@@ -9,15 +9,37 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
+/**
+ * 入札が成立したことを表す Event。
+ *
+ * ShouldBroadcast を実装しているため、サーバ内 Listener への配送に加えて
+ * Reverb (WebSocket) 経由でブラウザにも push される。
+ *
+ * Event クラスは「起きたことを表すデータの入れ物 (DTO)」であり、
+ * 発生源 (BidController) と受け取り側 (Broadcaster / Listener) を疎結合にする。
+ */
 class BidPlaced implements ShouldBroadcast
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
+    /**
+     * Event が運ぶデータをコンストラクタで受け取り、そのままプロパティに保持する。
+     *
+     * SerializesModels trait のおかげで、キュー経由で渡される際は
+     * Bid モデルが ID にシリアライズされ、受信側で自動的に再フェッチされる。
+     */
     public function __construct(public Bid $bid)
     {
     }
 
     /**
+     * このイベントを流すブロードキャストチャンネルを返す。
+     *
+     * "宛先" にあたる。auction.{id} という公開チャンネルを使用しており、
+     * 同じオークションを観戦している全クライアントが受信できる。
+     * 認証が必要なら PrivateChannel / PresenceChannel を使い、
+     * routes/channels.php で認可ロジックを書く。
+     *
      * @return array<int, Channel>
      */
     public function broadcastOn(): array
@@ -25,12 +47,26 @@ class BidPlaced implements ShouldBroadcast
         return [new Channel("auction.{$this->bid->auction_id}")];
     }
 
+    /**
+     * フロントエンドが listen するイベント名 ("件名" にあたる)。
+     *
+     * 未定義だと FQCN (App\Events\BidPlaced) で配信されてしまうため、
+     * 短い識別子を明示する。Laravel Echo 側では先頭にドットを付けて
+     * .listen('.bid.placed', ...) と購読する (ドット無しだとクラス名扱いになる)。
+     */
     public function broadcastAs(): string
     {
         return 'bid.placed';
     }
 
     /**
+     * ブラウザに送る JSON ペイロード ("本文" にあたる)。
+     *
+     * 未定義だと Event の public プロパティが丸ごと JSON 化されてしまい、
+     * 不要な内部情報まで漏れたりスキーマ変更でフロントが壊れたりするため、
+     * 公開してよい項目だけを明示的に組み立てる。
+     * loadMissing でリレーションをまとめて読み込み、N+1 を防いでいる。
+     *
      * @return array<string, mixed>
      */
     public function broadcastWith(): array

--- a/app/Events/PingBroadcasted.php
+++ b/app/Events/PingBroadcasted.php
@@ -8,10 +8,37 @@ use Illuminate\Contracts\Broadcasting\ShouldBroadcast;
 use Illuminate\Foundation\Events\Dispatchable;
 use Illuminate\Queue\SerializesModels;
 
+/**
+ * WebSocket（Reverb）配信経路のスモークテスト用イベント。
+ *
+ * 本番のビジネスロジックでは使用しない。`POST /api/broadcast-test`
+ * （{@see \App\Http\Controllers\Api\BroadcastTestController}）から発火され、
+ * 公開チャンネル `public.ping` にイベント名 `ping` で配信される。
+ *
+ * 用途は「Laravel → Reverb → ブラウザ」の疎通確認のみ。
+ * 障害時に配信経路（インフラ・WebSocket）側の問題か、業務ロジック側の問題かを
+ * 切り分けるための診断用エンドポイントとして残している。
+ *
+ * 削除する場合は以下も併せて削除すること:
+ *   - {@see \App\Http\Controllers\Api\BroadcastTestController}
+ *   - routes/api.php の `api.broadcast-test` ルート
+ *   - routes/channels.php の `public.ping` チャンネル登録
+ *   - tests/Unit/Events/PingBroadcastedTest.php
+ *   - tests/Feature/Api/BroadcastTestControllerTest.php
+ */
 class PingBroadcasted implements ShouldBroadcast
 {
     use Dispatchable, InteractsWithSockets, SerializesModels;
 
+    /**
+     * 配信ペイロードを受け取って保持する。
+     *
+     * `$message` と `$emittedAt` はそのまま {@see self::broadcastWith()} を
+     * 通じてブラウザに送られる。
+     *
+     * @param string $message フロントに表示・ログ出力するための任意のメッセージ文字列
+     * @param string $emittedAt サーバ側でイベントを生成した時刻（ISO 8601 形式を想定）
+     */
     public function __construct(
         public string $message,
         public string $emittedAt,
@@ -19,6 +46,11 @@ class PingBroadcasted implements ShouldBroadcast
     }
 
     /**
+     * 配信先チャンネルを返す。
+     *
+     * 認証不要の公開チャンネル `public.ping` に流す。スモークテスト用途のため
+     * PrivateChannel ではなく Channel（公開）を使用している。
+     *
      * @return array<int, Channel>
      */
     public function broadcastOn(): array
@@ -26,12 +58,24 @@ class PingBroadcasted implements ShouldBroadcast
         return [new Channel('public.ping')];
     }
 
+    /**
+     * クライアント側で購読するイベント名を返す。
+     *
+     * 既定では完全修飾クラス名（`App\Events\PingBroadcasted`）になるが、
+     * フロント（Echo）側で `.listen('.ping', ...)` と短い名前で受信できるよう
+     * 短いエイリアス `ping` を返す。
+     */
     public function broadcastAs(): string
     {
         return 'ping';
     }
 
     /**
+     * ブラウザに送る JSON ペイロードを返す。
+     *
+     * public プロパティをそのまま送らず、キー名をスネークケースに整形する
+     * （フロント側 JS の命名規約に合わせるため）。
+     *
      * @return array<string, mixed>
      */
     public function broadcastWith(): array

--- a/app/Http/Controllers/Api/BroadcastTestController.php
+++ b/app/Http/Controllers/Api/BroadcastTestController.php
@@ -7,8 +7,31 @@ use App\Http\Controllers\Controller;
 use Illuminate\Http\JsonResponse;
 use Illuminate\Support\Carbon;
 
+/**
+ * WebSocket（Reverb）配信経路の疎通確認エンドポイント。
+ *
+ * `POST /api/broadcast-test` にアクセスすると {@see PingBroadcasted} を発火し、
+ * 公開チャンネル `public.ping` にイベント名 `ping` でブロードキャストする。
+ * レスポンス JSON には配信先チャンネル・イベント名・ペイロードを返すため、
+ * 「サーバ側が正常に発火したか」と「ブラウザ側が受信できたか」を別々に確認できる。
+ *
+ * 本番のビジネスロジックでは利用しない。障害切り分け（インフラ／WebSocket 側か、
+ * 業務ロジック側かの判定）専用の診断用ツールとして残している。
+ */
 class BroadcastTestController extends Controller
 {
+    /**
+     * 疎通確認イベントを発火し、配信内容を JSON で返す。
+     *
+     * `pong from Laravel` という固定メッセージと、サーバの現在時刻（ISO 8601）を
+     * ペイロードに乗せて {@see PingBroadcasted} を発火する。
+     * `broadcast()->toOthers()` を使っているため、同一接続のクライアント
+     * （X-Socket-Id を送ってきたリクエスト元）には配信されない点に注意。
+     *
+     * レスポンスにはサーバ側で組み立てた配信内容（チャンネル名・イベント名・
+     * ペイロード）をそのまま返すため、ブラウザ側で「受信できた値」と
+     * 「サーバが送ったはずの値」を突き合わせて疎通を判定できる。
+     */
     public function __invoke(): JsonResponse
     {
         $event = new PingBroadcasted(

--- a/app/Models/User.php
+++ b/app/Models/User.php
@@ -10,7 +10,20 @@ use Illuminate\Foundation\Auth\User as Authenticatable;
 use Illuminate\Notifications\Notifiable;
 use Laravel\Sanctum\HasApiTokens;
 
-/** @use HasFactory<UserFactory> */
+/**
+ * @use HasFactory<UserFactory>
+ *
+ * @property int $id
+ * @property string $name
+ * @property string $email
+ * @property string $password
+ * @property \Illuminate\Support\Carbon|null $last_login_at
+ * @property \Illuminate\Support\Carbon|null $email_verified_at
+ * @property string|null $remember_token
+ * @property \Illuminate\Support\Carbon|null $created_at
+ * @property \Illuminate\Support\Carbon|null $updated_at
+ * @property \Illuminate\Support\Carbon|null $deleted_at
+ */
 class User extends Authenticatable implements MustVerifyEmail
 {
     /** @use HasFactory<UserFactory> */


### PR DESCRIPTION
## Summary
- `BidPlaced` / `PingBroadcasted` / `BroadcastTestController` に、各クラス・各メソッドの責務（配信チャンネル・イベント名・ペイロード設計の意図など）を説明する学習用 PHPDoc を追加。
- `User` モデルにカラム由来の `@property` を宣言し、`$bid->bidder->id` / `name` 等のアクセスで PHPStorm が出していた「マジックメソッド経由でアクセスされるプロパティ」警告を解消。
- ロジック変更なし。PHPDoc / コメントの追加のみ。

## Why
- ブロードキャスト周りは Event / Channel / Listener の役割分担が直感的に追いにくいので、コード自体に「責務」と「削除時の影響範囲」を残して読み手の学習コストを下げる。
- `User` モデルは `@property` 未整備で、リレーション越しのプロパティアクセスに対し PHPStorm が常に Info 警告を出していた。他モデル（`Bid` / `Auction` 等）と同じく `@property` を宣言して整合を取った。

## Test plan
- [x] `make build`（csf / cs / sa / md）通過を確認
- [x] PHPStorm の `BidPlaced.php` 4 件の Info 警告が解消されたことを `getDiagnostics` で確認
- [ ] CI 通過

🤖 Generated with [Claude Code](https://claude.com/claude-code)